### PR TITLE
Implement board module with CKEditor 5 and JSON seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ lib/
 │   │   │   └── metamask_connector.dart
 │   │   └── view/
 │   │       └── login_page.dart
+│   ├── board/
+│   │   ├── controllers/
+│   │   │   └── board_controller.dart
+│   │   ├── data/
+│   │   │   └── board_repository.dart
+│   │   ├── models/
+│   │   │   ├── board_comment.dart
+│   │   │   └── board_post.dart
+│   │   ├── view/
+│   │   │   ├── board_page.dart
+│   │   │   ├── post_detail_page.dart
+│   │   │   └── post_editor_page.dart
+│   │   └── widgets/
+│   │       ├── ckeditor5.dart
+│   │       ├── ckeditor5_platform_io.dart
+│   │       ├── ckeditor5_platform_interface.dart
+│   │       ├── ckeditor5_platform_web.dart
+│   │       ├── comment_utils.dart
+│   │       ├── post_gallery_tile.dart
+│   │       └── post_list_tile.dart
 │   └── simple_page/
 │       └── simple_page.dart
 └── main.dart
@@ -43,7 +63,19 @@ lib/
   - `router/`: `GoRouter` 구성을 담당합니다.
 - **lib/features**: 실제 화면(Feature)을 모듈 단위로 관리합니다.
   - `auth/`: 로그인, 사용자/지갑 더미 데이터, 암호화 서비스를 포함하는 인증 모듈입니다.
+  - `board/`: 자유 게시판 기능(리스트/갤러리 전환, CKEditor 5 기반 에디터, 댓글/대댓글, 좋아요·싫어요·공유)을 제공합니다.
   - `simple_page/`: 개발 중인 메뉴를 대신 보여주는 플레이스홀더 화면입니다.
+
+## 자유 게시판 데이터
+
+- 초기 게시글 20건은 `assets/data/free_board.json`에 JSON 형식으로 저장되어 있으며, 앱 시작 시 로딩됩니다.
+- 게시글 본문은 CKEditor 5에서 생성한 HTML을 그대로 저장합니다. `assets/pics` 폴더에 포함된 이미지 리소스를 커버 및 첨부 이미지로 활용합니다.
+
+## CKEditor 5 통합
+
+- `lib/features/board/widgets/ckeditor5.dart`는 웹에서는 `HtmlElementView` + `iframe`, 모바일/데스크톱에서는 `webview_flutter`를 사용해 CKEditor 5 클래식 에디터를 임베드합니다.
+- Flutter ↔️ CKEditor 간 양방향 통신은 `window.postMessage`와 `JavaScriptChannel`을 통해 구현했습니다. 본문 변경 시 실시간으로 Flutter 상태가 갱신됩니다.
+- CKEditor 5 소스는 `lib/util/editor` 디렉터리에 포함되어 있으며, 현재는 CDN 번들을 사용하지만 추후 자체 빌드로 대체할 수 있습니다.
 
 ## Database Schema (Draft)
 
@@ -80,7 +112,15 @@ lib/
 | --- | --- | --- | --- |
 | `id` | BIGINT | PK | 게시글 ID |
 | `user_id` | CHAR(12) | FK(`users.id`) | 작성자 |
+| `nickname_snapshot` | VARCHAR(30) | NOT NULL | 게시 당시 닉네임 |
 | `title` | VARCHAR(200) | NOT NULL | 게시글 제목 |
+| `summary` | VARCHAR(280) | NULL | 리스트/갤러리용 요약 |
+| `content_html` | MEDIUMTEXT | NOT NULL | CKEditor 5 HTML 본문 |
+| `cover_image_path` | VARCHAR(120) | NULL | 대표 이미지 경로 |
+| `attachment_json` | JSON | NULL | 첨부 이미지/파일 메타데이터 |
+| `view_count` | INT | DEFAULT 0 | 조회수 |
+| `like_count` | INT | DEFAULT 0 | 좋아요 수 |
+| `dislike_count` | INT | DEFAULT 0 | 싫어요 수 |
 | `created_at` | DATETIME | NOT NULL | 작성 시각 |
 | `updated_at` | DATETIME | NOT NULL | 수정 시각 |
 

--- a/assets/data/free_board.json
+++ b/assets/data/free_board.json
@@ -1,0 +1,461 @@
+{
+  "posts": [
+    {
+      "id": "p01",
+      "title": "웹3 커뮤니티 온보딩 꿀팁",
+      "nickname": "청록고래",
+      "summary": "새로 합류한 회원이 빠르게 커뮤니티에 적응하도록 돕는 5가지 팁을 공유합니다.",
+      "content": "<p>신규 회원이 우리 커뮤니티의 분위기를 이해하고 적극적으로 참여할 수 있도록 돕는 온보딩 가이드입니다.</p><ul><li>첫 주차 웰컴 라이브 참여</li><li>자주 묻는 질문 모아보기</li><li>관심 주제별 소모임 안내</li><li>전문가 AMA 일정 공유</li><li>필수 보안 체크리스트 제공</li></ul>",
+      "coverImage": "assets/pics/1.jpg",
+      "createdAt": "2024-04-01T09:00:00+09:00",
+      "updatedAt": "2024-04-02T08:15:00+09:00",
+      "views": 154,
+      "likes": 37,
+      "dislikes": 2,
+      "images": [
+        "assets/pics/1.jpg",
+        "assets/pics/2.jpg"
+      ],
+      "comments": [
+        {
+          "id": "c01",
+          "nickname": "솔잎이",
+          "content": "온보딩 체크리스트 정리 감사합니다! 새내기에게 꼭 보여줘야겠어요.",
+          "createdAt": "2024-04-02T10:20:00+09:00",
+          "replies": [
+            {
+              "id": "c01-1",
+              "nickname": "청록고래",
+              "content": "도움이 된다니 기쁘네요. 웰컴 라이브 일정도 공유 부탁드려요!",
+              "createdAt": "2024-04-02T11:05:00+09:00",
+              "replies": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "p02",
+      "title": "DAO 투표 시스템 실험 후기",
+      "nickname": "메타연구원",
+      "summary": "최근 진행한 DAO 투표 실험에서 얻은 교훈과 데이터를 공개합니다.",
+      "content": "<p>세 가지 시나리오를 적용해 투표 참여율과 의사결정 품질을 비교했습니다. 특히 위임 투표가 참여율을 크게 끌어올렸습니다.</p>",
+      "coverImage": "assets/pics/2.jpg",
+      "createdAt": "2024-04-03T14:30:00+09:00",
+      "updatedAt": "2024-04-03T18:40:00+09:00",
+      "views": 201,
+      "likes": 58,
+      "dislikes": 4,
+      "images": [
+        "assets/pics/2.jpg",
+        "assets/pics/3.png"
+      ],
+      "comments": [
+        {
+          "id": "c02",
+          "nickname": "기술정책가",
+          "content": "위임 투표 관련 수치가 인상적이네요. 상세 레포트도 부탁드려요!",
+          "createdAt": "2024-04-03T19:10:00+09:00",
+          "replies": []
+        },
+        {
+          "id": "c02-1",
+          "nickname": "데이터픽서",
+          "content": "재현 실험 시 유의해야 할 조건이 있을까요?",
+          "createdAt": "2024-04-04T08:45:00+09:00",
+          "replies": [
+            {
+              "id": "c02-1-1",
+              "nickname": "메타연구원",
+              "content": "투표 기간을 48시간 이상 확보하는 것이 핵심이었습니다.",
+              "createdAt": "2024-04-04T09:05:00+09:00",
+              "replies": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "p03",
+      "title": "커뮤니티 디자인 시스템 업데이트",
+      "nickname": "UI코더",
+      "summary": "새로운 버튼 컴포넌트와 색상 시스템을 도입했습니다.",
+      "content": "<p>이번 업데이트에서는 접근성을 고려한 명도 대비와 모바일 가이드를 정리했습니다. 피그마 링크도 함께 첨부합니다.</p>",
+      "coverImage": "assets/pics/3.png",
+      "createdAt": "2024-04-05T09:45:00+09:00",
+      "updatedAt": "2024-04-05T09:45:00+09:00",
+      "views": 178,
+      "likes": 46,
+      "dislikes": 1,
+      "images": [
+        "assets/pics/3.png"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p04",
+      "title": "생태계 파트너십 제안서",
+      "nickname": "브릿지메이커",
+      "summary": "탈중앙 금융 플랫폼과의 협업 제안을 정리했습니다.",
+      "content": "<p>파트너사에게 제공할 수 있는 가치와 상호 프로모션 아이디어를 정리했습니다. 의견을 남겨주세요.</p>",
+      "coverImage": "assets/pics/4.gif",
+      "createdAt": "2024-04-06T12:00:00+09:00",
+      "updatedAt": "2024-04-07T08:10:00+09:00",
+      "views": 143,
+      "likes": 33,
+      "dislikes": 5,
+      "images": [
+        "assets/pics/4.gif",
+        "assets/pics/5.jpg"
+      ],
+      "comments": [
+        {
+          "id": "c04",
+          "nickname": "사업PM",
+          "content": "가치 제안 부분이 조금 더 구체적이면 좋겠습니다. KPI 초안도 추가해 주세요.",
+          "createdAt": "2024-04-07T09:20:00+09:00",
+          "replies": []
+        }
+      ]
+    },
+    {
+      "id": "p05",
+      "title": "모바일 앱 베타 테스트 일정",
+      "nickname": "릴리즈매니저",
+      "summary": "다음 주 시작하는 베타 테스트 일정을 공유합니다.",
+      "content": "<p>테스트 범위와 피드백 수집 폼 링크를 포함했습니다. iOS와 Android 동시에 시작합니다.</p>",
+      "coverImage": "assets/pics/5.jpg",
+      "createdAt": "2024-04-08T15:30:00+09:00",
+      "updatedAt": "2024-04-09T10:25:00+09:00",
+      "views": 265,
+      "likes": 72,
+      "dislikes": 3,
+      "images": [
+        "assets/pics/5.jpg",
+        "assets/pics/6.jpeg"
+      ],
+      "comments": [
+        {
+          "id": "c05",
+          "nickname": "테스트러",
+          "content": "안드로이드 13 이상에서도 설치 가능한가요?",
+          "createdAt": "2024-04-09T11:00:00+09:00",
+          "replies": [
+            {
+              "id": "c05-1",
+              "nickname": "릴리즈매니저",
+              "content": "네, 13 이상 버전에서도 정상 동작하도록 검증했습니다.",
+              "createdAt": "2024-04-09T11:20:00+09:00",
+              "replies": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "p06",
+      "title": "커뮤니티 가이드라인 개정 초안",
+      "nickname": "커뮤니티가드",
+      "summary": "혐오 발언 대응 프로토콜과 스팸 필터링 정책을 개정했습니다.",
+      "content": "<p>새로운 가이드라인은 구성원의 자율성을 보장하면서도 안전한 토론 환경을 목표로 합니다.</p>",
+      "coverImage": "assets/pics/6.jpeg",
+      "createdAt": "2024-04-10T09:10:00+09:00",
+      "updatedAt": "2024-04-10T17:00:00+09:00",
+      "views": 189,
+      "likes": 54,
+      "dislikes": 6,
+      "images": [
+        "assets/pics/6.jpeg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p07",
+      "title": "탈중앙 아이덴티티 실험",
+      "nickname": "DID탐험가",
+      "summary": "다양한 DID 프로토콜을 비교한 실험 결과를 공유합니다.",
+      "content": "<p>Polygon ID와 Ceramic 네트워크를 비교 테스트했습니다. 속도와 호환성 차이를 표로 정리했습니다.</p>",
+      "coverImage": "assets/pics/7.jpeg",
+      "createdAt": "2024-04-11T16:45:00+09:00",
+      "updatedAt": "2024-04-11T16:45:00+09:00",
+      "views": 132,
+      "likes": 28,
+      "dislikes": 1,
+      "images": [
+        "assets/pics/7.jpeg",
+        "assets/pics/8.webp"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p08",
+      "title": "교육 세션: 스마트컨트랙트 보안",
+      "nickname": "체크포인트",
+      "summary": "보안 교육 세션 자료와 다시보기 링크를 공유합니다.",
+      "content": "<p>재진입 공격과 오라클 조작 사례를 중심으로 설명했습니다. 실습 코드도 깃허브에 올려두었습니다.</p>",
+      "coverImage": "assets/pics/8.webp",
+      "createdAt": "2024-04-12T11:20:00+09:00",
+      "updatedAt": "2024-04-12T11:20:00+09:00",
+      "views": 221,
+      "likes": 63,
+      "dislikes": 2,
+      "images": [
+        "assets/pics/8.webp",
+        "assets/pics/9.webp"
+      ],
+      "comments": [
+        {
+          "id": "c08",
+          "nickname": "코드감시자",
+          "content": "실습 코드 감사하면서 몇 가지 의견 남겼습니다. 확인 부탁드려요!",
+          "createdAt": "2024-04-12T15:30:00+09:00",
+          "replies": []
+        }
+      ]
+    },
+    {
+      "id": "p09",
+      "title": "콘텐츠 큐레이션 주간 회고",
+      "nickname": "콘텐츠셰르파",
+      "summary": "이번 주에 큐레이션한 아티클과 영상을 정리했습니다.",
+      "content": "<p>회원 반응이 좋았던 자료와 다음 주 계획을 함께 공유합니다.</p>",
+      "coverImage": "assets/pics/9.webp",
+      "createdAt": "2024-04-13T09:00:00+09:00",
+      "updatedAt": "2024-04-13T09:00:00+09:00",
+      "views": 118,
+      "likes": 27,
+      "dislikes": 0,
+      "images": [
+        "assets/pics/9.webp"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p10",
+      "title": "커뮤니티 KPI 대시보드 베타",
+      "nickname": "데이터관리자",
+      "summary": "실시간 대시보드 베타 버전을 공개합니다.",
+      "content": "<p>활성 이용자, 기여도 점수, 지역 분포 등의 지표를 시각화했습니다. 피드백 환영합니다.</p>",
+      "coverImage": "assets/pics/1.jpg",
+      "createdAt": "2024-04-14T10:10:00+09:00",
+      "updatedAt": "2024-04-14T16:45:00+09:00",
+      "views": 247,
+      "likes": 70,
+      "dislikes": 7,
+      "images": [
+        "assets/pics/1.jpg",
+        "assets/pics/5.webp"
+      ],
+      "comments": [
+        {
+          "id": "c10",
+          "nickname": "지표덕후",
+          "content": "기여도 점수 계산 방식이 궁금합니다. 설명 추가 부탁드려요.",
+          "createdAt": "2024-04-14T18:05:00+09:00",
+          "replies": []
+        }
+      ]
+    },
+    {
+      "id": "p11",
+      "title": "NFT 커머스 실험 브리핑",
+      "nickname": "마켓플래너",
+      "summary": "파일럿으로 진행한 NFT 굿즈 판매 결과를 공유합니다.",
+      "content": "<p>한정판 발행과 멤버십 결합 전략이 긍정적인 반응을 얻었습니다. 개선 포인트도 정리했습니다.</p>",
+      "coverImage": "assets/pics/2.jpg",
+      "createdAt": "2024-04-15T13:40:00+09:00",
+      "updatedAt": "2024-04-16T08:25:00+09:00",
+      "views": 176,
+      "likes": 39,
+      "dislikes": 3,
+      "images": [
+        "assets/pics/2.jpg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p12",
+      "title": "번역팀 프로젝트 관리 팁",
+      "nickname": "언어마스터",
+      "summary": "다국어 번역 파이프라인을 자동화한 경험을 공유합니다.",
+      "content": "<p>GitHub Actions와 DeepL API를 연동해 번역 품질을 유지하는 방법을 정리했습니다.</p>",
+      "coverImage": "assets/pics/3.png",
+      "createdAt": "2024-04-16T09:00:00+09:00",
+      "updatedAt": "2024-04-16T09:00:00+09:00",
+      "views": 134,
+      "likes": 31,
+      "dislikes": 1,
+      "images": [
+        "assets/pics/3.png",
+        "assets/pics/6.jpeg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p13",
+      "title": "로컬 밋업 운영 가이드",
+      "nickname": "커넥터",
+      "summary": "성공적인 로컬 밋업을 위한 체크리스트를 정리했습니다.",
+      "content": "<p>장소 선정, 프로그램 구성, 후속 커뮤니케이션까지 단계별로 정리했습니다.</p>",
+      "coverImage": "assets/pics/4.gif",
+      "createdAt": "2024-04-17T11:15:00+09:00",
+      "updatedAt": "2024-04-18T07:40:00+09:00",
+      "views": 165,
+      "likes": 44,
+      "dislikes": 2,
+      "images": [
+        "assets/pics/4.gif",
+        "assets/pics/7.jpeg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p14",
+      "title": "메타버스 스테이지 리허설",
+      "nickname": "스테이지디렉터",
+      "summary": "메타버스 스테이지 베타 리허설 상황을 공유합니다.",
+      "content": "<p>오디오 싱크 문제 해결 과정과 관객 동선 설계를 정리했습니다.</p>",
+      "coverImage": "assets/pics/5.jpg",
+      "createdAt": "2024-04-18T20:30:00+09:00",
+      "updatedAt": "2024-04-19T09:10:00+09:00",
+      "views": 142,
+      "likes": 29,
+      "dislikes": 3,
+      "images": [
+        "assets/pics/5.jpg",
+        "assets/pics/9.webp"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p15",
+      "title": "AI 요약 봇 실험",
+      "nickname": "오토메이터",
+      "summary": "커뮤니티 요약 봇 베타 결과를 공개합니다.",
+      "content": "<p>주간 요약 정확도와 피드백 반영 로드맵을 공유합니다.</p>",
+      "coverImage": "assets/pics/6.jpeg",
+      "createdAt": "2024-04-19T08:20:00+09:00",
+      "updatedAt": "2024-04-19T08:20:00+09:00",
+      "views": 198,
+      "likes": 52,
+      "dislikes": 4,
+      "images": [
+        "assets/pics/6.jpeg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p16",
+      "title": "커뮤니티 멘토링 프로그램",
+      "nickname": "멘토링리드",
+      "summary": "멘토단 구성과 운영 계획을 설명합니다.",
+      "content": "<p>멘토 프로필과 매칭 프로세스를 안내합니다. 지원 폼 링크도 포함했습니다.</p>",
+      "coverImage": "assets/pics/7.jpeg",
+      "createdAt": "2024-04-20T09:00:00+09:00",
+      "updatedAt": "2024-04-21T12:10:00+09:00",
+      "views": 157,
+      "likes": 36,
+      "dislikes": 1,
+      "images": [
+        "assets/pics/7.jpeg",
+        "assets/pics/1.jpg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p17",
+      "title": "탈중앙 보상 시스템 설계",
+      "nickname": "토큰디자이너",
+      "summary": "기여도 기반 보상 시스템 설계 초안을 공유합니다.",
+      "content": "<p>보상 풀 배분과 락업 전략을 수식과 함께 정리했습니다.</p>",
+      "coverImage": "assets/pics/8.webp",
+      "createdAt": "2024-04-21T10:35:00+09:00",
+      "updatedAt": "2024-04-21T10:35:00+09:00",
+      "views": 210,
+      "likes": 61,
+      "dislikes": 6,
+      "images": [
+        "assets/pics/8.webp"
+      ],
+      "comments": [
+        {
+          "id": "c17",
+          "nickname": "토큰검토자",
+          "content": "락업 해제 조건이 조금 더 명확했으면 좋겠습니다.",
+          "createdAt": "2024-04-21T13:00:00+09:00",
+          "replies": []
+        }
+      ]
+    },
+    {
+      "id": "p18",
+      "title": "제휴 뉴스레터 배포 결과",
+      "nickname": "뉴스레터장인",
+      "summary": "외부 파트너와 함께한 뉴스레터 배포 지표를 공유합니다.",
+      "content": "<p>오픈율과 클릭률이 모두 목표치를 상회했습니다. 상세 표는 엑셀로 첨부했습니다.</p>",
+      "coverImage": "assets/pics/9.webp",
+      "createdAt": "2024-04-22T09:50:00+09:00",
+      "updatedAt": "2024-04-22T09:50:00+09:00",
+      "views": 175,
+      "likes": 38,
+      "dislikes": 2,
+      "images": [
+        "assets/pics/9.webp",
+        "assets/pics/5.jpg"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p19",
+      "title": "신규 멤버 온체인 인증 흐름",
+      "nickname": "시스템설계자",
+      "summary": "온체인 인증 프로세스 다이어그램을 공유합니다.",
+      "content": "<p>지갑 연결, 증명 발급, 커뮤니티 입장을 순차적으로 안내합니다.</p>",
+      "coverImage": "assets/pics/1.jpg",
+      "createdAt": "2024-04-23T08:30:00+09:00",
+      "updatedAt": "2024-04-23T08:30:00+09:00",
+      "views": 149,
+      "likes": 34,
+      "dislikes": 3,
+      "images": [
+        "assets/pics/1.jpg",
+        "assets/pics/4.gif"
+      ],
+      "comments": []
+    },
+    {
+      "id": "p20",
+      "title": "월간 운영 보고서",
+      "nickname": "운영리더",
+      "summary": "4월 운영 현황을 정리한 월간 보고서 초안입니다.",
+      "content": "<p>회원 성장, 재무 지표, 주요 이슈와 해결 과정을 요약했습니다.</p>",
+      "coverImage": "assets/pics/2.jpg",
+      "createdAt": "2024-04-24T10:00:00+09:00",
+      "updatedAt": "2024-04-24T16:30:00+09:00",
+      "views": 233,
+      "likes": 68,
+      "dislikes": 5,
+      "images": [
+        "assets/pics/2.jpg",
+        "assets/pics/3.png"
+      ],
+      "comments": [
+        {
+          "id": "c20",
+          "nickname": "재무분석가",
+          "content": "재무 지표 그래프를 다음 주까지 공유 부탁드립니다.",
+          "createdAt": "2024-04-24T18:10:00+09:00",
+          "replies": [
+            {
+              "id": "c20-1",
+              "nickname": "운영리더",
+              "content": "네, 이번 주 회의 자료에 포함하겠습니다.",
+              "createdAt": "2024-04-24T19:00:00+09:00",
+              "replies": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/lib/app/navigation/app_destinations.dart
+++ b/lib/app/navigation/app_destinations.dart
@@ -2,6 +2,7 @@
 // 파일 설명: 어댑티브 셸 라우터에서 사용할 목적지를 정의.
 import 'package:flutter/material.dart';
 import 'package:untitled3/features/auth/view/login_page.dart';
+import 'package:untitled3/features/board/view/board_page.dart';
 import 'package:untitled3/features/simple_page/simple_page.dart';
 
 class AppDestination {
@@ -40,7 +41,7 @@ final List<AppDestination> appDestinations = [
     name: 'free',
     label: '자유',
     icon: Icons.forum_outlined,
-    builder: (_) => const SimplePage(message: '자유 게시판이 준비 중입니다.'),
+    builder: (_) => const BoardPage(),
   ),
   AppDestination(
     location: '/experiment',

--- a/lib/features/board/controllers/board_controller.dart
+++ b/lib/features/board/controllers/board_controller.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
+
+import '../data/board_repository.dart';
+import '../models/board_comment.dart';
+import '../models/board_post.dart';
+
+class BoardController extends ChangeNotifier {
+  BoardController({
+    required BoardRepository repository,
+  }) : _repository = repository;
+
+  final BoardRepository _repository;
+  final List<BoardPost> _posts = <BoardPost>[];
+  bool _isLoading = false;
+  BoardViewMode _viewMode = BoardViewMode.list;
+
+  bool get isLoading => _isLoading;
+  BoardViewMode get viewMode => _viewMode;
+  List<BoardPost> get posts => List<BoardPost>.unmodifiable(_posts);
+
+  Future<void> loadInitialPosts() async {
+    if (_isLoading) {
+      return;
+    }
+    _isLoading = true;
+    notifyListeners();
+    try {
+      final loadedPosts = await _repository.loadPosts();
+      _posts
+        ..clear()
+        ..addAll(loadedPosts);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  BoardPost? findById(String id) {
+    try {
+      return _posts.firstWhere((post) => post.id == id);
+    } on StateError {
+      return null;
+    }
+  }
+
+  void setViewMode(BoardViewMode mode) {
+    if (_viewMode == mode) {
+      return;
+    }
+    _viewMode = mode;
+    notifyListeners();
+  }
+
+  void addPost(BoardPost post) {
+    _posts.insert(0, post);
+    notifyListeners();
+  }
+
+  void updatePost(BoardPost updated) {
+    final index = _posts.indexWhere((post) => post.id == updated.id);
+    if (index == -1) {
+      return;
+    }
+    _posts[index] = updated;
+    notifyListeners();
+  }
+
+  void deletePost(String id) {
+    _posts.removeWhere((post) => post.id == id);
+    notifyListeners();
+  }
+
+  void registerView(String id) {
+    _updatePost(id, (post) {
+      return post.copyWith(views: post.views + 1);
+    });
+  }
+
+  void reactToPost(String id, {required bool like}) {
+    _updatePost(id, (post) {
+      if (like) {
+        return post.copyWith(likes: post.likes + 1);
+      }
+      return post.copyWith(dislikes: post.dislikes + 1);
+    });
+  }
+
+  void addComment(
+    String postId,
+    BoardComment comment, {
+    String? parentCommentId,
+  }) {
+    _updatePost(postId, (post) {
+      final now = DateTime.now();
+      if (parentCommentId == null) {
+        return post.copyWith(
+          comments: <BoardComment>[...post.comments, comment],
+          updatedAt: now,
+        );
+      }
+      final (updatedComments, inserted) =
+          _insertReply(post.comments, parentCommentId, comment);
+      if (!inserted) {
+        return post;
+      }
+      return post.copyWith(
+        comments: updatedComments,
+        updatedAt: now,
+      );
+    });
+  }
+
+  void deleteComment(String postId, String commentId) {
+    _updatePost(postId, (post) {
+      final (comments, removed) = _removeComment(post.comments, commentId);
+      if (!removed) {
+        return post;
+      }
+      return post.copyWith(comments: comments, updatedAt: DateTime.now());
+    });
+  }
+
+  String generateCommentId() => const Uuid().v4();
+
+  void _updatePost(String id, BoardPost Function(BoardPost post) transform) {
+    final index = _posts.indexWhere((post) => post.id == id);
+    if (index == -1) {
+      return;
+    }
+    final updated = transform(_posts[index]);
+    _posts[index] = updated;
+    notifyListeners();
+  }
+
+  (List<BoardComment>, bool) _insertReply(
+    List<BoardComment> comments,
+    String parentId,
+    BoardComment reply,
+  ) {
+    final List<BoardComment> updated = <BoardComment>[];
+    var inserted = false;
+    for (final comment in comments) {
+      if (comment.id == parentId) {
+        inserted = true;
+        updated.add(
+          comment.copyWith(
+            replies: <BoardComment>[...comment.replies, reply],
+          ),
+        );
+      } else {
+        final (childReplies, childInserted) =
+            _insertReply(comment.replies, parentId, reply);
+        if (childInserted) {
+          inserted = true;
+          updated.add(comment.copyWith(replies: childReplies));
+        } else {
+          updated.add(comment);
+        }
+      }
+    }
+    return (updated, inserted);
+  }
+
+  (List<BoardComment>, bool) _removeComment(
+    List<BoardComment> comments,
+    String commentId,
+  ) {
+    final List<BoardComment> updated = <BoardComment>[];
+    var removed = false;
+    for (final comment in comments) {
+      if (comment.id == commentId) {
+        removed = true;
+        continue;
+      }
+      final (childReplies, childRemoved) =
+          _removeComment(comment.replies, commentId);
+      if (childRemoved) {
+        removed = true;
+        updated.add(comment.copyWith(replies: childReplies));
+      } else {
+        updated.add(comment);
+      }
+    }
+    return (updated, removed);
+  }
+}

--- a/lib/features/board/data/board_repository.dart
+++ b/lib/features/board/data/board_repository.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+import '../models/board_post.dart';
+
+class BoardRepository {
+  const BoardRepository({
+    this.assetPath = 'assets/data/free_board.json',
+    this.bundle = rootBundle,
+  });
+
+  final String assetPath;
+  final AssetBundle bundle;
+
+  Future<List<BoardPost>> loadPosts() async {
+    final raw = await bundle.loadString(assetPath);
+    final Map<String, dynamic> jsonMap = json.decode(raw) as Map<String, dynamic>;
+    final posts = jsonMap['posts'] as List<dynamic>? ?? <dynamic>[];
+    return [
+      for (final post in posts)
+        BoardPost.fromJson(post as Map<String, dynamic>),
+    ];
+  }
+}

--- a/lib/features/board/models/board_comment.dart
+++ b/lib/features/board/models/board_comment.dart
@@ -1,0 +1,61 @@
+import 'package:equatable/equatable.dart';
+
+class BoardComment extends Equatable {
+  const BoardComment({
+    required this.id,
+    required this.nickname,
+    required this.content,
+    required this.createdAt,
+    this.replies = const <BoardComment>[],
+  });
+
+  final String id;
+  final String nickname;
+  final String content;
+  final DateTime createdAt;
+  final List<BoardComment> replies;
+
+  BoardComment copyWith({
+    String? id,
+    String? nickname,
+    String? content,
+    DateTime? createdAt,
+    List<BoardComment>? replies,
+  }) {
+    return BoardComment(
+      id: id ?? this.id,
+      nickname: nickname ?? this.nickname,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      replies: replies ?? this.replies,
+    );
+  }
+
+  factory BoardComment.fromJson(Map<String, dynamic> json) {
+    return BoardComment(
+      id: json['id'] as String,
+      nickname: json['nickname'] as String,
+      content: json['content'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      replies: [
+        for (final reply in json['replies'] as List<dynamic>? ?? <dynamic>[])
+          BoardComment.fromJson(reply as Map<String, dynamic>),
+      ],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'nickname': nickname,
+      'content': content,
+      'createdAt': createdAt.toIso8601String(),
+      'replies': [
+        for (final reply in replies) reply.toJson(),
+      ],
+    };
+  }
+
+  @override
+  List<Object?> get props => [id, nickname, content, createdAt, replies];
+}

--- a/lib/features/board/models/board_post.dart
+++ b/lib/features/board/models/board_post.dart
@@ -1,0 +1,135 @@
+import 'package:equatable/equatable.dart';
+
+import 'board_comment.dart';
+
+enum BoardViewMode {
+  list,
+  gallery,
+}
+
+class BoardPost extends Equatable {
+  const BoardPost({
+    required this.id,
+    required this.title,
+    required this.nickname,
+    required this.summary,
+    required this.content,
+    required this.coverImage,
+    required this.createdAt,
+    required this.updatedAt,
+    required this.views,
+    required this.likes,
+    required this.dislikes,
+    this.images = const <String>[],
+    this.comments = const <BoardComment>[],
+  });
+
+  final String id;
+  final String title;
+  final String nickname;
+  final String summary;
+  final String content;
+  final String coverImage;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final int views;
+  final int likes;
+  final int dislikes;
+  final List<String> images;
+  final List<BoardComment> comments;
+
+  BoardPost copyWith({
+    String? id,
+    String? title,
+    String? nickname,
+    String? summary,
+    String? content,
+    String? coverImage,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    int? views,
+    int? likes,
+    int? dislikes,
+    List<String>? images,
+    List<BoardComment>? comments,
+  }) {
+    return BoardPost(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      nickname: nickname ?? this.nickname,
+      summary: summary ?? this.summary,
+      content: content ?? this.content,
+      coverImage: coverImage ?? this.coverImage,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      views: views ?? this.views,
+      likes: likes ?? this.likes,
+      dislikes: dislikes ?? this.dislikes,
+      images: images ?? this.images,
+      comments: comments ?? this.comments,
+    );
+  }
+
+  factory BoardPost.fromJson(Map<String, dynamic> json) {
+    return BoardPost(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      nickname: json['nickname'] as String,
+      summary: json['summary'] as String? ?? '',
+      content: json['content'] as String,
+      coverImage: json['coverImage'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      views: json['views'] as int? ?? 0,
+      likes: json['likes'] as int? ?? 0,
+      dislikes: json['dislikes'] as int? ?? 0,
+      images: [
+        for (final image in json['images'] as List<dynamic>? ?? <dynamic>[])
+          image as String,
+      ],
+      comments: [
+        for (final comment in json['comments'] as List<dynamic>? ?? <dynamic>[])
+          BoardComment.fromJson(comment as Map<String, dynamic>),
+      ],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'nickname': nickname,
+      'summary': summary,
+      'content': content,
+      'coverImage': coverImage,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'views': views,
+      'likes': likes,
+      'dislikes': dislikes,
+      'images': images,
+      'comments': [
+        for (final comment in comments) comment.toJson(),
+      ],
+    };
+  }
+
+  String get shareMessage => '[청록 네트워크] $title';
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        nickname,
+        summary,
+        content,
+        coverImage,
+        createdAt,
+        updatedAt,
+        views,
+        likes,
+        dislikes,
+        images,
+        comments,
+      ];
+}

--- a/lib/features/board/view/board_page.dart
+++ b/lib/features/board/view/board_page.dart
@@ -1,0 +1,222 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/board_controller.dart';
+import '../data/board_repository.dart';
+import '../models/board_post.dart';
+import 'post_detail_page.dart';
+import 'post_editor_page.dart';
+import 'widgets/post_gallery_tile.dart';
+import 'widgets/post_list_tile.dart';
+
+class BoardPage extends StatelessWidget {
+  const BoardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<BoardController>(
+      create: (_) => BoardController(repository: const BoardRepository())
+        ..loadInitialPosts(),
+      child: const _BoardView(),
+    );
+  }
+}
+
+class _BoardView extends StatelessWidget {
+  const _BoardView();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final controller = context.watch<BoardController>();
+    return Stack(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _BoardToolbar(controller: controller),
+              const SizedBox(height: 16),
+              Expanded(
+                child: controller.isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : _BoardContent(controller: controller),
+              ),
+            ],
+          ),
+        ),
+        Positioned(
+          bottom: 16,
+          right: 16,
+          child: FloatingActionButton.extended(
+            onPressed: () => _openEditor(context),
+            icon: const Icon(Icons.edit_outlined),
+            label: const Text('새 글 작성'),
+            backgroundColor: theme.colorScheme.primary,
+            foregroundColor: theme.colorScheme.onPrimary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _openEditor(BuildContext context) {
+    final controller = context.read<BoardController>();
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ChangeNotifierProvider<BoardController>.value(
+          value: controller,
+          child: const PostEditorPage(),
+        ),
+      ),
+    );
+  }
+}
+
+class _BoardToolbar extends StatelessWidget {
+  const _BoardToolbar({required this.controller});
+
+  final BoardController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          '커뮤니티 게시판',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            SegmentedButton<BoardViewMode>(
+              segments: const [
+                ButtonSegment<BoardViewMode>(
+                  value: BoardViewMode.list,
+                  icon: Icon(Icons.view_list_outlined),
+                  label: Text('리스트'),
+                ),
+                ButtonSegment<BoardViewMode>(
+                  value: BoardViewMode.gallery,
+                  icon: Icon(Icons.grid_view_rounded),
+                  label: Text('갤러리'),
+                ),
+              ],
+              selected: <BoardViewMode>{controller.viewMode},
+              onSelectionChanged: (selection) {
+                controller.setViewMode(selection.first);
+              },
+            ),
+            const SizedBox(width: 12),
+            Text(
+              '총 ${controller.posts.length}건',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _BoardContent extends StatelessWidget {
+  const _BoardContent({required this.controller});
+
+  final BoardController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final posts = controller.posts;
+    if (posts.isEmpty) {
+      return const Center(child: Text('등록된 글이 없습니다. 첫 번째 글을 작성해보세요.'));
+    }
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 250),
+      child: controller.viewMode == BoardViewMode.list
+          ? _PostListView(
+              key: const ValueKey('list'),
+              posts: posts,
+            )
+          : _PostGalleryView(
+              key: const ValueKey('gallery'),
+              posts: posts,
+            ),
+    );
+  }
+}
+
+class _PostListView extends StatelessWidget {
+  const _PostListView({required this.posts, super.key});
+
+  final List<BoardPost> posts;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.read<BoardController>();
+    final dateFormat = DateFormat('yyyy.MM.dd HH:mm');
+    return ListView.separated(
+      itemCount: posts.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final post = posts[index];
+        return PostListTile(
+          post: post,
+          formattedDate: dateFormat.format(post.updatedAt),
+          onTap: () => _openDetail(context, controller, post),
+        );
+      },
+    );
+  }
+}
+
+class _PostGalleryView extends StatelessWidget {
+  const _PostGalleryView({required this.posts, super.key});
+
+  final List<BoardPost> posts;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.read<BoardController>();
+    final columns = MediaQuery.of(context).size.width > 900
+        ? 4
+        : MediaQuery.of(context).size.width > 600
+            ? 3
+            : 2;
+    final dateFormat = DateFormat('MM/dd HH:mm');
+    return GridView.builder(
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: columns,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+        childAspectRatio: 0.82,
+      ),
+      itemCount: posts.length,
+      itemBuilder: (context, index) {
+        final post = posts[index];
+        return PostGalleryTile(
+          post: post,
+          formattedDate: dateFormat.format(post.updatedAt),
+          onTap: () => _openDetail(context, controller, post),
+        );
+      },
+    );
+  }
+}
+
+void _openDetail(BuildContext context, BoardController controller, BoardPost post) {
+  controller.registerView(post.id);
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (_) => ChangeNotifierProvider<BoardController>.value(
+        value: controller,
+        child: PostDetailPage(postId: post.id),
+      ),
+    ),
+  );
+}

--- a/lib/features/board/view/post_detail_page.dart
+++ b/lib/features/board/view/post_detail_page.dart
@@ -1,0 +1,480 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../controllers/board_controller.dart';
+import '../models/board_comment.dart';
+import '../models/board_post.dart';
+import '../widgets/comment_utils.dart';
+import 'post_editor_page.dart';
+
+class PostDetailPage extends StatelessWidget {
+  const PostDetailPage({
+    required this.postId,
+    super.key,
+  });
+
+  final String postId;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<BoardController>();
+    final post = controller.findById(postId);
+    if (post == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('게시글 상세')),
+        body: const Center(child: Text('게시글을 찾을 수 없습니다.')),
+      );
+    }
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat('yyyy.MM.dd HH:mm');
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(post.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share_outlined),
+            tooltip: '공유',
+            onPressed: () => _sharePost(post),
+          ),
+          PopupMenuButton<String>(
+            onSelected: (value) {
+              switch (value) {
+                case 'edit':
+                  _editPost(context, controller, post);
+                  break;
+                case 'delete':
+                  _deletePost(context, controller, post);
+                  break;
+              }
+            },
+            itemBuilder: (context) => const [
+              PopupMenuItem(value: 'edit', child: Text('수정')), 
+              PopupMenuItem(value: 'delete', child: Text('삭제')),
+            ],
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              post.title,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                _MetaChip(icon: Icons.person_outline, label: post.nickname),
+                _MetaChip(
+                  icon: Icons.schedule_outlined,
+                  label: '작성 ${dateFormat.format(post.createdAt)}',
+                ),
+                _MetaChip(
+                  icon: Icons.edit_calendar_outlined,
+                  label: '수정 ${dateFormat.format(post.updatedAt)}',
+                ),
+                _MetaChip(icon: Icons.remove_red_eye_outlined, label: '${post.views}'),
+                _MetaChip(icon: Icons.thumb_up_outlined, label: '${post.likes}'),
+                _MetaChip(icon: Icons.thumb_down_outlined, label: '${post.dislikes}'),
+                _MetaChip(icon: Icons.chat_bubble_outline, label: '${countComments(post.comments)}'),
+              ],
+            ),
+            const SizedBox(height: 16),
+            ClipRRect(
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+              child: Image.asset(
+                post.coverImage,
+                height: 220,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Container(
+                    height: 220,
+                    color: theme.colorScheme.surfaceVariant,
+                    alignment: Alignment.center,
+                    child: const Icon(Icons.broken_image_outlined, size: 48),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 24),
+            HtmlWidget(
+              post.content,
+              renderMode: RenderMode.column,
+              customStylesBuilder: (element) {
+                if (element.localName == 'ul') {
+                  return {'padding-left': '18px'};
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    icon: const Icon(Icons.thumb_up_alt_outlined),
+                    label: Text('좋아요 ${post.likes}'),
+                    onPressed: () => controller.reactToPost(post.id, like: true),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton.tonalIcon(
+                    icon: const Icon(Icons.thumb_down_alt_outlined),
+                    label: Text('싫어요 ${post.dislikes}'),
+                    onPressed: () => controller.reactToPost(post.id, like: false),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 32),
+            CommentSection(postId: post.id, comments: post.comments),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _sharePost(BoardPost post) {
+    final url = 'https://cheongrok.community/posts/${post.id}';
+    Share.share('${post.shareMessage}\n$url');
+  }
+
+  Future<void> _editPost(
+    BuildContext context,
+    BoardController controller,
+    BoardPost post,
+  ) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => ChangeNotifierProvider<BoardController>.value(
+          value: controller,
+          child: PostEditorPage(initialPost: post),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _deletePost(
+    BuildContext context,
+    BoardController controller,
+    BoardPost post,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('게시글 삭제'),
+        content: Text('"${post.title}" 글을 삭제하시겠습니까?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(false), child: const Text('취소')),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      controller.deletePost(post.id);
+      Navigator.of(context).pop();
+    }
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 18, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 4),
+        Text(label, style: Theme.of(context).textTheme.bodySmall),
+      ],
+    );
+  }
+}
+
+class CommentSection extends StatefulWidget {
+  const CommentSection({
+    required this.postId,
+    required this.comments,
+    super.key,
+  });
+
+  final String postId;
+  final List<BoardComment> comments;
+
+  @override
+  State<CommentSection> createState() => _CommentSectionState();
+}
+
+class _CommentSectionState extends State<CommentSection> {
+  final TextEditingController _nicknameController = TextEditingController();
+  final TextEditingController _contentController = TextEditingController();
+  BoardComment? _replyTarget;
+
+  @override
+  void dispose() {
+    _nicknameController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<BoardController>();
+    final dateFormat = DateFormat('yyyy.MM.dd HH:mm');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          '댓글 ${countComments(widget.comments)}',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        if (_replyTarget != null)
+          Container(
+            padding: const EdgeInsets.all(12),
+            margin: const EdgeInsets.only(bottom: 12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.6),
+              borderRadius: const BorderRadius.all(Radius.circular(12)),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '답글 대상: ${_replyTarget!.nickname}',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ),
+                TextButton(
+                  onPressed: () => setState(() => _replyTarget = null),
+                  child: const Text('취소'),
+                ),
+              ],
+            ),
+          ),
+        TextField(
+          controller: _nicknameController,
+          decoration: const InputDecoration(
+            labelText: '닉네임',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        TextField(
+          controller: _contentController,
+          minLines: 3,
+          maxLines: 5,
+          decoration: const InputDecoration(
+            labelText: '댓글 내용',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerRight,
+          child: FilledButton.icon(
+            onPressed: () => _submitComment(controller),
+            icon: const Icon(Icons.send_outlined),
+            label: Text(_replyTarget == null ? '댓글 등록' : '답글 등록'),
+          ),
+        ),
+        const SizedBox(height: 24),
+        _CommentThread(
+          comments: widget.comments,
+          onReply: (comment) => setState(() => _replyTarget = comment),
+          onDelete: (comment) => _deleteComment(context, controller, comment),
+          dateFormat: dateFormat,
+        ),
+      ],
+    );
+  }
+
+  Future<void> _submitComment(BoardController controller) async {
+    final nickname = _nicknameController.text.trim();
+    final content = _contentController.text.trim();
+    if (nickname.isEmpty || content.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('닉네임과 내용을 모두 입력해 주세요.')),
+      );
+      return;
+    }
+    final comment = BoardComment(
+      id: controller.generateCommentId(),
+      nickname: nickname,
+      content: content,
+      createdAt: DateTime.now(),
+    );
+    controller.addComment(
+      widget.postId,
+      comment,
+      parentCommentId: _replyTarget?.id,
+    );
+    setState(() {
+      _contentController.clear();
+      _replyTarget = null;
+    });
+  }
+
+  Future<void> _deleteComment(
+    BuildContext context,
+    BoardController controller,
+    BoardComment comment,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('댓글 삭제'),
+        content: const Text('댓글을 삭제하시겠습니까?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(false), child: const Text('취소')),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      controller.deleteComment(widget.postId, comment.id);
+    }
+  }
+}
+
+class _CommentThread extends StatelessWidget {
+  const _CommentThread({
+    required this.comments,
+    required this.onReply,
+    required this.onDelete,
+    required this.dateFormat,
+  });
+
+  final List<BoardComment> comments;
+  final ValueChanged<BoardComment> onReply;
+  final ValueChanged<BoardComment> onDelete;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    if (comments.isEmpty) {
+      return const Text('첫 번째 댓글을 남겨보세요.');
+    }
+    return Column(
+      children: [
+        for (final comment in comments)
+          _CommentTile(
+            comment: comment,
+            onReply: onReply,
+            onDelete: onDelete,
+            dateFormat: dateFormat,
+            depth: 0,
+          ),
+      ],
+    );
+  }
+}
+
+class _CommentTile extends StatelessWidget {
+  const _CommentTile({
+    required this.comment,
+    required this.onReply,
+    required this.onDelete,
+    required this.dateFormat,
+    required this.depth,
+  });
+
+  final BoardComment comment;
+  final ValueChanged<BoardComment> onReply;
+  final ValueChanged<BoardComment> onDelete;
+  final DateFormat dateFormat;
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    final indent = depth * 16.0;
+    return Container(
+      margin: EdgeInsets.only(left: indent, bottom: 16),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+        borderRadius: const BorderRadius.all(Radius.circular(12)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  comment.nickname,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                ),
+              ),
+              Text(
+                dateFormat.format(comment.createdAt),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(comment.content),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 12,
+            children: [
+              TextButton.icon(
+                onPressed: () => onReply(comment),
+                icon: const Icon(Icons.reply_outlined, size: 18),
+                label: const Text('답글'),
+              ),
+              TextButton.icon(
+                onPressed: () => onDelete(comment),
+                icon: const Icon(Icons.delete_outline, size: 18),
+                label: const Text('삭제'),
+              ),
+            ],
+          ),
+          if (comment.replies.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 12),
+              child: Column(
+                children: [
+                  for (final reply in comment.replies)
+                    _CommentTile(
+                      comment: reply,
+                      onReply: onReply,
+                      onDelete: onDelete,
+                      dateFormat: dateFormat,
+                      depth: depth + 1,
+                    ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/board/view/post_editor_page.dart
+++ b/lib/features/board/view/post_editor_page.dart
@@ -1,0 +1,285 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:uuid/uuid.dart';
+
+import '../controllers/board_controller.dart';
+import '../models/board_post.dart';
+import '../widgets/ckeditor5.dart';
+
+class PostEditorPage extends StatefulWidget {
+  const PostEditorPage({
+    this.initialPost,
+    super.key,
+  });
+
+  final BoardPost? initialPost;
+
+  bool get isEditing => initialPost != null;
+
+  @override
+  State<PostEditorPage> createState() => _PostEditorPageState();
+}
+
+class _PostEditorPageState extends State<PostEditorPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _titleController;
+  late final TextEditingController _nicknameController;
+  late final TextEditingController _summaryController;
+  late final Ckeditor5Controller _contentController;
+  late String _coverImage;
+  late List<String> _selectedImages;
+
+  static const List<String> _availableImages = [
+    'assets/pics/1.jpg',
+    'assets/pics/2.jpg',
+    'assets/pics/3.png',
+    'assets/pics/4.gif',
+    'assets/pics/5.jpg',
+    'assets/pics/5.webp',
+    'assets/pics/6.jpeg',
+    'assets/pics/7.jpeg',
+    'assets/pics/8.webp',
+    'assets/pics/9.webp',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initialPost;
+    _titleController = TextEditingController(text: initial?.title ?? '');
+    _nicknameController = TextEditingController(text: initial?.nickname ?? '');
+    _summaryController = TextEditingController(text: initial?.summary ?? '');
+    _contentController = Ckeditor5Controller(initialHtml: initial?.content ?? '');
+    _coverImage = initial?.coverImage ?? _availableImages.first;
+    _selectedImages = List<String>.from(initial?.images ?? <String>[]);
+    if (!_selectedImages.contains(_coverImage)) {
+      _selectedImages.insert(0, _coverImage);
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _nicknameController.dispose();
+    _summaryController.dispose();
+    _contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.isEditing;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? '게시글 수정' : '새 게시글 작성'),
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            TextFormField(
+              controller: _titleController,
+              decoration: const InputDecoration(
+                labelText: '제목',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '제목을 입력해 주세요.';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _nicknameController,
+              decoration: const InputDecoration(
+                labelText: '작성자 닉네임',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return '닉네임을 입력해 주세요.';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _summaryController,
+              decoration: const InputDecoration(
+                labelText: '요약 설명',
+                hintText: '리스트나 갤러리에서 보일 짧은 설명을 입력하세요.',
+                border: OutlineInputBorder(),
+              ),
+              minLines: 2,
+              maxLines: 4,
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _coverImage,
+              decoration: const InputDecoration(
+                labelText: '대표 이미지',
+                border: OutlineInputBorder(),
+              ),
+              items: [
+                for (final path in _availableImages)
+                  DropdownMenuItem(
+                    value: path,
+                    child: Row(
+                      children: [
+                        _ImagePreview(path: path, size: 32),
+                        const SizedBox(width: 8),
+                        Text(path.split('/').last),
+                      ],
+                    ),
+                  ),
+              ],
+              onChanged: (value) {
+                if (value == null) {
+                  return;
+                }
+                setState(() {
+                  _coverImage = value;
+                  if (!_selectedImages.contains(value)) {
+                    _selectedImages.insert(0, value);
+                  }
+                });
+              },
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '첨부 이미지',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final path in _availableImages)
+                  FilterChip(
+                    label: Text(path.split('/').last),
+                    avatar: _ImagePreview(path: path, size: 24),
+                    selected: _selectedImages.contains(path),
+                    onSelected: (selected) {
+                      setState(() {
+                        if (selected) {
+                          _selectedImages.add(path);
+                        } else {
+                          if (path == _coverImage) {
+                            return;
+                          }
+                          _selectedImages.remove(path);
+                        }
+                      });
+                    },
+                  ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            Text(
+              '본문 내용',
+              style: Theme.of(context).textTheme.titleSmall,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 400,
+              child: Ckeditor5(controller: _contentController),
+            ),
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: _handleSubmit,
+              icon: Icon(isEditing ? Icons.save_outlined : Icons.publish_outlined),
+              label: Text(isEditing ? '게시글 수정' : '게시글 등록'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleSubmit() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    final controller = context.read<BoardController>();
+    final html = await _contentController.getHtml();
+    final plainText = html.replaceAll(RegExp(r'<[^>]+>'), '').replaceAll('&nbsp;', '').trim();
+    if (plainText.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('본문 내용을 입력해 주세요.')),
+        );
+      }
+      return;
+    }
+    final now = DateTime.now();
+    final images = <String>{..._selectedImages, _coverImage}.toList();
+    if (widget.initialPost == null) {
+      final newPost = BoardPost(
+        id: const Uuid().v4(),
+        title: _titleController.text.trim(),
+        nickname: _nicknameController.text.trim(),
+        summary: _summaryController.text.trim(),
+        content: html,
+        coverImage: _coverImage,
+        createdAt: now,
+        updatedAt: now,
+        views: 0,
+        likes: 0,
+        dislikes: 0,
+        images: images,
+        comments: const [],
+      );
+      controller.addPost(newPost);
+    } else {
+      final updated = widget.initialPost!.copyWith(
+        title: _titleController.text.trim(),
+        nickname: _nicknameController.text.trim(),
+        summary: _summaryController.text.trim(),
+        content: html,
+        coverImage: _coverImage,
+        images: images,
+        updatedAt: now,
+      );
+      controller.updatePost(updated);
+    }
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+}
+
+class _ImagePreview extends StatelessWidget {
+  const _ImagePreview({
+    required this.path,
+    required this.size,
+  });
+
+  final String path;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: const BorderRadius.all(Radius.circular(6)),
+      child: Image.asset(
+        path,
+        width: size,
+        height: size,
+        fit: BoxFit.cover,
+        errorBuilder: (context, error, stackTrace) {
+          return Container(
+            width: size,
+            height: size,
+            color: Theme.of(context).colorScheme.surfaceVariant,
+            alignment: Alignment.center,
+            child: const Icon(Icons.broken_image_outlined, size: 16),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/board/view/widgets/post_gallery_tile.dart
+++ b/lib/features/board/view/widgets/post_gallery_tile.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+import '../../models/board_post.dart';
+import '../../widgets/comment_utils.dart';
+
+class PostGalleryTile extends StatelessWidget {
+  const PostGalleryTile({
+    required this.post,
+    required this.formattedDate,
+    required this.onTap,
+    super.key,
+  });
+
+  final BoardPost post;
+  final String formattedDate;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 1,
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Expanded(
+              child: ClipRRect(
+                borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                child: Image.asset(
+                  post.coverImage,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) {
+                    return Container(
+                      color: theme.colorScheme.surfaceVariant,
+                      alignment: Alignment.center,
+                      child: const Icon(Icons.broken_image_outlined, size: 32),
+                    );
+                  },
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    post.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Text(
+                    post.summary.isEmpty ? '상세 내용을 확인해보세요.' : post.summary,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.textTheme.bodySmall?.color?.withOpacity(0.75),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Flexible(
+                        child: Text(
+                          post.nickname,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        formattedDate,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.textTheme.bodySmall?.color?.withOpacity(0.7),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 6),
+                  Row(
+                    children: [
+                      _IconStat(icon: Icons.remove_red_eye_outlined, value: post.views),
+                      const SizedBox(width: 12),
+                      _IconStat(icon: Icons.thumb_up_outlined, value: post.likes),
+                      const SizedBox(width: 12),
+                      _IconStat(icon: Icons.chat_bubble_outline, value: countComments(post.comments)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IconStat extends StatelessWidget {
+  const _IconStat({
+    required this.icon,
+    required this.value,
+  });
+
+  final IconData icon;
+  final int value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 4),
+        Text(
+          '$value',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/board/view/widgets/post_list_tile.dart
+++ b/lib/features/board/view/widgets/post_list_tile.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+
+import '../../models/board_post.dart';
+import '../../widgets/comment_utils.dart';
+
+class PostListTile extends StatelessWidget {
+  const PostListTile({
+    required this.post,
+    required this.formattedDate,
+    required this.onTap,
+    super.key,
+  });
+
+  final BoardPost post;
+  final String formattedDate;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 1,
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 150,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              AspectRatio(
+                aspectRatio: 4 / 3,
+                child: _PostImage(path: post.coverImage),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        post.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Expanded(
+                        child: Text(
+                          post.summary.isEmpty ? '상세 내용을 확인해보세요.' : post.summary,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 12,
+                        runSpacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          _InfoChip(
+                            icon: Icons.person_outline,
+                            label: post.nickname,
+                          ),
+                          _InfoChip(
+                            icon: Icons.schedule_outlined,
+                            label: formattedDate,
+                          ),
+                          _InfoChip(
+                            icon: Icons.remove_red_eye_outlined,
+                            label: '${post.views}',
+                          ),
+                          _InfoChip(
+                            icon: Icons.thumb_up_outlined,
+                            label: '${post.likes}',
+                          ),
+                          _InfoChip(
+                            icon: Icons.thumb_down_outlined,
+                            label: '${post.dislikes}',
+                          ),
+                          _InfoChip(
+                            icon: Icons.chat_bubble_outline,
+                            label: '${countComments(post.comments)}',
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PostImage extends StatelessWidget {
+  const _PostImage({required this.path});
+
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.asset(
+      path,
+      fit: BoxFit.cover,
+      errorBuilder: (context, error, stackTrace) {
+        return Container(
+          color: Theme.of(context).colorScheme.surfaceVariant,
+          alignment: Alignment.center,
+          child: const Icon(Icons.broken_image_outlined, size: 32),
+        );
+      },
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({
+    required this.icon,
+    required this.label,
+  });
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 18, color: Theme.of(context).colorScheme.primary),
+        const SizedBox(width: 4),
+        Text(
+          label,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/board/widgets/ckeditor5.dart
+++ b/lib/features/board/widgets/ckeditor5.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+
+import 'ckeditor5_platform_interface.dart'
+    if (dart.library.html) 'ckeditor5_platform_web.dart'
+    if (dart.library.io) 'ckeditor5_platform_io.dart';
+
+class Ckeditor5Controller {
+  Ckeditor5Controller({String initialHtml = ''})
+      : _html = initialHtml,
+        htmlListenable = ValueNotifier<String>(initialHtml),
+        readyListenable = ValueNotifier<bool>(false);
+
+  final ValueNotifier<String> htmlListenable;
+  final ValueNotifier<bool> readyListenable;
+
+  String _html;
+  _Ckeditor5State? _state;
+
+  String get initialHtml => _html;
+
+  void _bind(_Ckeditor5State state) {
+    _state = state;
+  }
+
+  void _unbind(_Ckeditor5State state) {
+    if (identical(_state, state)) {
+      _state = null;
+    }
+  }
+
+  Future<void> setHtml(String html) async {
+    _html = html;
+    htmlListenable.value = html;
+    if (_state != null) {
+      await _state!.setHtmlFromController(html);
+    }
+  }
+
+  Future<String> getHtml() async {
+    if (_state != null) {
+      _html = await _state!.getHtmlFromEditor();
+      htmlListenable.value = _html;
+    }
+    return _html;
+  }
+
+  void _handleHtmlChanged(String html) {
+    _html = html;
+    htmlListenable.value = html;
+  }
+
+  void _markReady() {
+    readyListenable.value = true;
+  }
+
+  void dispose() {
+    htmlListenable.dispose();
+    readyListenable.dispose();
+  }
+}
+
+class Ckeditor5 extends StatefulWidget {
+  const Ckeditor5({
+    required this.controller,
+    this.minHeight = 320,
+    super.key,
+  });
+
+  final Ckeditor5Controller controller;
+  final double minHeight;
+
+  @override
+  State<Ckeditor5> createState() => _Ckeditor5State();
+}
+
+class _Ckeditor5State extends State<Ckeditor5> {
+  Future<void> Function(String html)? _setHtmlCallback;
+  Future<String> Function()? _getHtmlCallback;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller._bind(this);
+  }
+
+  @override
+  void didUpdateWidget(Ckeditor5 oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.controller, widget.controller)) {
+      oldWidget.controller._unbind(this);
+      widget.controller._bind(this);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller._unbind(this);
+    super.dispose();
+  }
+
+  void registerCallbacks({
+    required Future<void> Function(String html) setHtml,
+    required Future<String> Function() getHtml,
+  }) {
+    _setHtmlCallback = setHtml;
+    _getHtmlCallback = getHtml;
+  }
+
+  Future<void> setHtmlFromController(String html) async {
+    if (_setHtmlCallback != null) {
+      await _setHtmlCallback!(html);
+    }
+  }
+
+  Future<String> getHtmlFromEditor() async {
+    if (_getHtmlCallback != null) {
+      return _getHtmlCallback!();
+    }
+    return widget.controller.initialHtml;
+  }
+
+  void handleEditorReady() {
+    widget.controller._markReady();
+    if (widget.controller.initialHtml.isNotEmpty) {
+      setHtmlFromController(widget.controller.initialHtml);
+    }
+  }
+
+  void handleHtmlChanged(String html) {
+    widget.controller._handleHtmlChanged(html);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return buildPlatformEditor(
+      minHeight: widget.minHeight,
+      initialHtml: widget.controller.initialHtml,
+      registerCallbacks: registerCallbacks,
+      onReady: handleEditorReady,
+      onChanged: handleHtmlChanged,
+    );
+  }
+}

--- a/lib/features/board/widgets/ckeditor5_platform_interface.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_interface.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+typedef CkeditorRegisterCallbacks = void Function({
+  required Future<void> Function(String html) setHtml,
+  required Future<String> Function() getHtml,
+});
+
+typedef CkeditorReadyCallback = void Function();
+typedef CkeditorChangedCallback = void Function(String html);
+
+Widget buildPlatformEditor({
+  required double minHeight,
+  required String initialHtml,
+  required CkeditorRegisterCallbacks registerCallbacks,
+  required CkeditorReadyCallback onReady,
+  required CkeditorChangedCallback onChanged,
+}) {
+  return Container(
+    constraints: BoxConstraints(minHeight: minHeight),
+    padding: const EdgeInsets.all(16),
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.grey.shade400),
+      borderRadius: const BorderRadius.all(Radius.circular(12)),
+    ),
+    alignment: Alignment.center,
+    child: const Text('현재 플랫폼에서는 CKEditor 5를 사용할 수 없습니다.'),
+  );
+}

--- a/lib/features/board/widgets/ckeditor5_platform_io.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_io.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'ckeditor5_platform_interface.dart' hide buildPlatformEditor;
+
+Widget buildPlatformEditor({
+  required double minHeight,
+  required String initialHtml,
+  required CkeditorRegisterCallbacks registerCallbacks,
+  required CkeditorReadyCallback onReady,
+  required CkeditorChangedCallback onChanged,
+}) {
+  final controller = WebViewController()
+    ..setJavaScriptMode(JavaScriptMode.unrestricted)
+    ..setBackgroundColor(Colors.transparent);
+
+  Completer<String>? pendingContentRequest;
+
+  controller.addJavaScriptChannel(
+    'FlutterEditorChannel',
+    onMessageReceived: (JavaScriptMessage message) {
+      final Map<String, dynamic> payload =
+          json.decode(message.message) as Map<String, dynamic>;
+      switch (payload['type'] as String? ?? '') {
+        case 'ready':
+          onReady();
+          break;
+        case 'change':
+          onChanged(payload['data'] as String? ?? '');
+          break;
+        case 'data':
+          pendingContentRequest?.complete(payload['data'] as String? ?? '');
+          pendingContentRequest = null;
+          break;
+      }
+    },
+  );
+
+  controller.loadHtmlString(_buildEditorHtml(initialHtml));
+
+  registerCallbacks(
+    setHtml: (String value) async {
+      final encoded = jsonEncode(<String, dynamic>{
+        'type': 'setData',
+        'data': value,
+      });
+      await controller.runJavaScript('window.handleMessage($encoded);');
+    },
+    getHtml: () {
+      pendingContentRequest = Completer<String>();
+      controller.runJavaScript('window.handleMessage({"type":"getData"});');
+      return pendingContentRequest!.future;
+    },
+  );
+
+  return Container(
+    constraints: BoxConstraints(minHeight: minHeight),
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.grey.shade400),
+      borderRadius: const BorderRadius.all(Radius.circular(12)),
+    ),
+    clipBehavior: Clip.antiAlias,
+    child: WebViewWidget(controller: controller),
+  );
+}
+
+String _buildEditorHtml(String initialHtml) {
+  final escapedInitial = jsonEncode(initialHtml);
+  return '''
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body { margin: 0; padding: 0; background: transparent; }
+    #editor { min-height: 280px; }
+  </style>
+  <script src="https://cdn.ckeditor.com/ckeditor5/41.2.0/classic/ckeditor.js"></script>
+</head>
+<body>
+  <div id="editor"></div>
+  <script>
+    const channelName = 'FlutterEditorChannel';
+    let editorInstance = null;
+
+    function postMessage(payload) {
+      if (window[channelName] && window[channelName].postMessage) {
+        window[channelName].postMessage(JSON.stringify(payload));
+      }
+      if (window.parent !== window && window.parent.postMessage) {
+        window.parent.postMessage(payload, '*');
+      }
+    }
+
+    function applyInitialData(data) {
+      if (editorInstance) {
+        editorInstance.setData(data || '');
+      }
+    }
+
+    window.handleMessage = function(payload) {
+      if (!editorInstance) {
+        return null;
+      }
+      if (payload.type === 'setData') {
+        editorInstance.setData(payload.data || '');
+      }
+      if (payload.type === 'getData') {
+        postMessage({ type: 'data', data: editorInstance.getData() });
+      }
+      return null;
+    };
+
+    ClassicEditor.create(document.querySelector('#editor'), {
+      toolbar: {
+        shouldNotGroupWhenFull: true
+      }
+    }).then(editor => {
+      editorInstance = editor;
+      editor.model.document.on('change:data', () => {
+        postMessage({ type: 'change', data: editor.getData() });
+      });
+      applyInitialData(${escapedInitial});
+      postMessage({ type: 'ready' });
+    }).catch(error => {
+      console.error(error);
+    });
+  </script>
+</body>
+</html>
+''';
+}

--- a/lib/features/board/widgets/ckeditor5_platform_web.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_web.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:html' as html;
+import 'dart:ui_web' as ui;
+
+import 'package:flutter/material.dart';
+
+import 'ckeditor5_platform_interface.dart' hide buildPlatformEditor;
+
+Widget buildPlatformEditor({
+  required double minHeight,
+  required String initialHtml,
+  required CkeditorRegisterCallbacks registerCallbacks,
+  required CkeditorReadyCallback onReady,
+  required CkeditorChangedCallback onChanged,
+}) {
+  final editorId = 'ck-${DateTime.now().microsecondsSinceEpoch}';
+  final viewType = 'ckeditor5-view-$editorId';
+  final iframe = html.IFrameElement()
+    ..style.border = '0'
+    ..style.width = '100%'
+    ..style.height = '100%'
+    ..srcdoc = _buildEditorHtml(initialHtml, editorId);
+
+  ui.platformViewRegistry.registerViewFactory(viewType, (int viewId) => iframe);
+
+  Completer<String>? pendingContentRequest;
+
+  html.window.onMessage.listen((event) {
+    final data = event.data;
+    Map<String, dynamic>? payload;
+    if (data is String) {
+      try {
+        payload = json.decode(data) as Map<String, dynamic>;
+      } catch (_) {
+        payload = null;
+      }
+    } else if (data is Map) {
+      payload = <String, dynamic>{
+        for (final entry in data.entries)
+          if (entry.key is String) entry.key as String: entry.value,
+      };
+    }
+    if (payload == null || payload['editorId'] != editorId) {
+      return;
+    }
+    switch (payload['type'] as String? ?? '') {
+      case 'ready':
+        onReady();
+        break;
+      case 'change':
+        onChanged(payload['data'] as String? ?? '');
+        break;
+      case 'data':
+        pendingContentRequest?.complete(payload['data'] as String? ?? '');
+        pendingContentRequest = null;
+        break;
+    }
+  });
+
+  registerCallbacks(
+    setHtml: (String value) async {
+      final message = jsonEncode(<String, dynamic>{
+        'editorId': editorId,
+        'type': 'setData',
+        'data': value,
+      });
+      iframe.contentWindow?.postMessage(message, '*');
+    },
+    getHtml: () {
+      pendingContentRequest = Completer<String>();
+      final message = jsonEncode(<String, dynamic>{
+        'editorId': editorId,
+        'type': 'getData',
+      });
+      iframe.contentWindow?.postMessage(message, '*');
+      return pendingContentRequest!.future;
+    },
+  );
+
+  return Container(
+    constraints: BoxConstraints(minHeight: minHeight),
+    decoration: BoxDecoration(
+      border: Border.all(color: Colors.grey.shade400),
+      borderRadius: const BorderRadius.all(Radius.circular(12)),
+    ),
+    clipBehavior: Clip.antiAlias,
+    child: HtmlElementView(viewType: viewType, onPlatformViewCreated: (_) {
+      // no-op, subscription already active
+    }),
+  );
+}
+
+String _buildEditorHtml(String initialHtml, String editorId) {
+  final escapedInitial = jsonEncode(initialHtml);
+  final escapedId = jsonEncode(editorId);
+  return '''
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body { margin: 0; padding: 0; background: transparent; }
+    #editor { min-height: 280px; }
+  </style>
+  <script src="https://cdn.ckeditor.com/ckeditor5/41.2.0/classic/ckeditor.js"></script>
+</head>
+<body>
+  <div id="editor"></div>
+  <script>
+    const editorId = ${escapedId};
+    let editorInstance = null;
+
+    function postMessage(payload) {
+      payload.editorId = editorId;
+      if (window.parent && window.parent !== window) {
+        window.parent.postMessage(JSON.stringify(payload), '*');
+      }
+    }
+
+    window.handleMessage = function(payload) {
+      if (!editorInstance) {
+        return null;
+      }
+      if (payload.type === 'setData') {
+        editorInstance.setData(payload.data || '');
+      }
+      if (payload.type === 'getData') {
+        postMessage({ type: 'data', data: editorInstance.getData() });
+      }
+      return null;
+    };
+
+    ClassicEditor.create(document.querySelector('#editor'), {
+      toolbar: {
+        shouldNotGroupWhenFull: true
+      }
+    }).then(editor => {
+      editorInstance = editor;
+      editor.model.document.on('change:data', () => {
+        postMessage({ type: 'change', data: editor.getData() });
+      });
+      editor.setData(${escapedInitial} || '');
+      postMessage({ type: 'ready' });
+      window.addEventListener('message', event => {
+        let payload = event.data;
+        if (typeof payload === 'string') {
+          try {
+            payload = JSON.parse(payload);
+          } catch (error) {
+            payload = null;
+          }
+        }
+        if (payload && payload.editorId === editorId) {
+          window.handleMessage(payload);
+        }
+      });
+    }).catch(error => {
+      console.error(error);
+    });
+  </script>
+</body>
+</html>
+''';
+}

--- a/lib/features/board/widgets/comment_utils.dart
+++ b/lib/features/board/widgets/comment_utils.dart
@@ -1,0 +1,9 @@
+import '../models/board_comment.dart';
+
+int countComments(List<BoardComment> comments) {
+  var total = 0;
+  for (final comment in comments) {
+    total += 1 + countComments(comment.replies);
+  }
+  return total;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,12 @@ dependencies:
   go_router: ^14.3.0
   provider: ^6.1.2
   encrypt: ^5.0.3
+  intl: ^0.19.0
+  share_plus: ^7.2.1
+  uuid: ^4.5.1
+  flutter_widget_from_html_core: ^0.15.1
+  webview_flutter: ^4.8.0
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:
@@ -61,6 +67,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/pics/
+    - assets/data/
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Summary
- add a board feature with list/gallery toggles and hook it into the navigation shell
- enable CKEditor 5-backed post creation, detail views with reactions, sharing, and nested comments
- seed 20 sample posts, extend README/schema guidance, and pull in the required dependencies/assets

## Testing
- flutter pub get *(fails: flutter command is not available in the container)*
- dart format lib *(fails: dart command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d339f2a0888322a725c626df77172a