### PR TITLE
Implement CKEditor-powered community board

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ lib/
 │   │   │   └── metamask_connector.dart
 │   │   └── view/
 │   │       └── login_page.dart
+│   ├── board/
+│   │   ├── controllers/
+│   │   │   └── board_controller.dart
+│   │   ├── data/
+│   │   │   └── asset_user_post_repository.dart
+│   │   ├── models/
+│   │   │   ├── post_comment.dart
+│   │   │   └── user_post.dart
+│   │   ├── view/
+│   │   │   ├── board_page.dart
+│   │   │   ├── post_detail_page.dart
+│   │   │   └── post_editor_page.dart
+│   │   └── widgets/
+│   │       ├── comment_thread.dart
+│   │       ├── post_gallery_view.dart
+│   │       ├── post_list_view.dart
+│   │       └── post_meta_row.dart
 │   └── simple_page/
 │       └── simple_page.dart
 └── main.dart
@@ -43,7 +60,19 @@ lib/
   - `router/`: `GoRouter` 구성을 담당합니다.
 - **lib/features**: 실제 화면(Feature)을 모듈 단위로 관리합니다.
   - `auth/`: 로그인, 사용자/지갑 더미 데이터, 암호화 서비스를 포함하는 인증 모듈입니다.
+  - `board/`: CKEditor 5 기반 게시판. 목록/갤러리 전환, 글 작성·수정·삭제, 대댓글, 좋아요·싫어요·공유 등 상호작용을 제공합니다. 데이터는 `assets/data/user_posts.json`에 포함된 20개의 더미 글에서 로드됩니다.
   - `simple_page/`: 개발 중인 메뉴를 대신 보여주는 플레이스홀더 화면입니다.
+
+## Community Board
+
+자유 게시판은 웹과 앱 모두에서 동일하게 동작하도록 반응형으로 구현했습니다.
+
+- **레이아웃 전환**: 상단 `SegmentedButton`으로 리스트형 ↔ 갤러리형을 즉시 전환합니다. 두 레이아웃은 `post_list_view.dart`와 `post_gallery_view.dart`로 분리돼 있어 확장과 유지보수가 쉽습니다.
+- **글 작성/수정**: `PostEditorPage`에서 CKEditor 5 (`lib/util/editor`)를 활용한 리치 텍스트 편집을 제공합니다. 모바일/데스크톱에서는 `webview_flutter`, 웹에서는 `HtmlElementView`로 에디터를 임베드했습니다.
+- **글 삭제 & 공유**: 상세 페이지에서 삭제 확인 다이얼로그, 조회수 자동 증가, 링크 복사 기반 공유 버튼을 지원합니다.
+- **반응형 상세 화면**: 작성/수정일, 닉네임, 태그, 첨부 이미지, 조회수·좋아요·싫어요 통계를 모두 노출합니다.
+- **댓글/대댓글**: `CommentThread`가 트리 구조를 렌더링하고, 닉네임과 내용을 입력받아 대댓글까지 작성할 수 있습니다.
+- **더미 데이터**: `assets/data/user_posts.json`에는 20개의 환경/커뮤니티 주제 글과 대댓글이 포함되어 있어 개발 중에도 다양한 상태를 확인할 수 있습니다.
 
 ## Database Schema (Draft)
 
@@ -80,7 +109,16 @@ lib/
 | --- | --- | --- | --- |
 | `id` | BIGINT | PK | 게시글 ID |
 | `user_id` | CHAR(12) | FK(`users.id`) | 작성자 |
+| `nickname` | VARCHAR(30) | NOT NULL | 화면에 노출될 닉네임 (실명 대신) |
 | `title` | VARCHAR(200) | NOT NULL | 게시글 제목 |
+| `summary` | VARCHAR(400) | NOT NULL | 목록·갤러리용 요약 텍스트 |
+| `content` | LONGTEXT | NOT NULL | CKEditor 5에서 작성한 HTML 본문 |
+| `thumbnail_path` | VARCHAR(255) | NULL | 대표 이미지 경로 |
+| `attachments_json` | JSON | NULL | 첨부 미디어 경로 배열 |
+| `views` | INT | DEFAULT 0 | 조회수 |
+| `likes` | INT | DEFAULT 0 | 좋아요 수 |
+| `dislikes` | INT | DEFAULT 0 | 싫어요 수 |
+| `share_slug` | VARCHAR(80) | UNIQUE | 공유 URL 생성을 위한 슬러그 |
 | `created_at` | DATETIME | NOT NULL | 작성 시각 |
 | `updated_at` | DATETIME | NOT NULL | 수정 시각 |
 

--- a/assets/data/user_posts.json
+++ b/assets/data/user_posts.json
@@ -1,0 +1,922 @@
+[
+  {
+    "id": "POST-001",
+    "title": "해양 플라스틱 제로 도전기",
+    "nickname": "푸른고래",
+    "summary": "플라스틱 수거 챌린지를 진행하며 느낀 점을 정리했습니다.",
+    "content": "<h2>해양 플라스틱 제로 도전기</h2><p>플라스틱 수거 챌린지를 진행하며 느낀 점을 정리했습니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/1.jpg",
+    "attachments": [
+      "assets/pics/4.gif"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#01"
+    ],
+    "views": 120,
+    "likes": 40,
+    "dislikes": 0,
+    "createdAt": "2024-01-05T09:00:00Z",
+    "updatedAt": "2024-01-05T21:00:00Z",
+    "comments": [
+      {
+        "id": "C01A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-05T09:00:00Z",
+        "children": [
+          {
+            "id": "C01B",
+            "nickname": "푸른고래",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-05T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C01C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-06T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-002",
+    "title": "도심 속 작은 숲 만들기",
+    "nickname": "도시여우",
+    "summary": "아파트 단지에 작은 숲을 조성하는 과정을 공유합니다.",
+    "content": "<h2>도심 속 작은 숲 만들기</h2><p>아파트 단지에 작은 숲을 조성하는 과정을 공유합니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/2.jpg",
+    "attachments": [
+      "assets/pics/5.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#02"
+    ],
+    "views": 135,
+    "likes": 42,
+    "dislikes": 1,
+    "createdAt": "2024-01-06T09:00:00Z",
+    "updatedAt": "2024-01-06T21:00:00Z",
+    "comments": [
+      {
+        "id": "C02A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-06T09:00:00Z",
+        "children": [
+          {
+            "id": "C02B",
+            "nickname": "도시여우",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-06T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C02C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-07T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-003",
+    "title": "태양광 발전 협동조합 후기",
+    "nickname": "햇살라이더",
+    "summary": "친구들과 함께 만든 태양광 협동조합 운영 후기입니다.",
+    "content": "<h2>태양광 발전 협동조합 후기</h2><p>친구들과 함께 만든 태양광 협동조합 운영 후기입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/3.png",
+    "attachments": [
+      "assets/pics/5.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#03"
+    ],
+    "views": 150,
+    "likes": 44,
+    "dislikes": 2,
+    "createdAt": "2024-01-07T09:00:00Z",
+    "updatedAt": "2024-01-07T21:00:00Z",
+    "comments": [
+      {
+        "id": "C03A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-07T09:00:00Z",
+        "children": [
+          {
+            "id": "C03B",
+            "nickname": "햇살라이더",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-07T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C03C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-08T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-004",
+    "title": "북극곰을 위한 절전 습관",
+    "nickname": "북극곰지킴이",
+    "summary": "일상에서 실천한 절전 습관과 노하우를 소개합니다.",
+    "content": "<h2>북극곰을 위한 절전 습관</h2><p>일상에서 실천한 절전 습관과 노하우를 소개합니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/4.gif",
+    "attachments": [
+      "assets/pics/6.jpeg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#04"
+    ],
+    "views": 165,
+    "likes": 46,
+    "dislikes": 3,
+    "createdAt": "2024-01-08T09:00:00Z",
+    "updatedAt": "2024-01-08T21:00:00Z",
+    "comments": [
+      {
+        "id": "C04A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-08T09:00:00Z",
+        "children": [
+          {
+            "id": "C04B",
+            "nickname": "북극곰지킴이",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-08T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C04C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-09T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-005",
+    "title": "제로 웨이스트 장보기 팁",
+    "nickname": "알뜰살뜰",
+    "summary": "일회용품 없는 장보기를 위한 체크리스트입니다.",
+    "content": "<h2>제로 웨이스트 장보기 팁</h2><p>일회용품 없는 장보기를 위한 체크리스트입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/5.jpg",
+    "attachments": [
+      "assets/pics/7.jpeg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#05"
+    ],
+    "views": 180,
+    "likes": 48,
+    "dislikes": 4,
+    "createdAt": "2024-01-09T09:00:00Z",
+    "updatedAt": "2024-01-09T21:00:00Z",
+    "comments": [
+      {
+        "id": "C05A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-09T09:00:00Z",
+        "children": [
+          {
+            "id": "C05B",
+            "nickname": "알뜰살뜰",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-09T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C05C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-10T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-006",
+    "title": "친환경 벽지 DIY",
+    "nickname": "숲속공방",
+    "summary": "친환경 페인트와 벽지를 활용한 셀프 인테리어 후기입니다.",
+    "content": "<h2>친환경 벽지 DIY</h2><p>친환경 페인트와 벽지를 활용한 셀프 인테리어 후기입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/5.webp",
+    "attachments": [
+      "assets/pics/8.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#06"
+    ],
+    "views": 195,
+    "likes": 50,
+    "dislikes": 0,
+    "createdAt": "2024-01-10T09:00:00Z",
+    "updatedAt": "2024-01-10T21:00:00Z",
+    "comments": [
+      {
+        "id": "C06A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-10T09:00:00Z",
+        "children": [
+          {
+            "id": "C06B",
+            "nickname": "숲속공방",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-10T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C06C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-11T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-007",
+    "title": "리사이클 패션 스튜디오",
+    "nickname": "패션몽타주",
+    "summary": "헌 옷을 새롭게 디자인한 과정을 기록했습니다.",
+    "content": "<h2>리사이클 패션 스튜디오</h2><p>헌 옷을 새롭게 디자인한 과정을 기록했습니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/6.jpeg",
+    "attachments": [
+      "assets/pics/9.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#07"
+    ],
+    "views": 210,
+    "likes": 52,
+    "dislikes": 1,
+    "createdAt": "2024-01-11T09:00:00Z",
+    "updatedAt": "2024-01-11T21:00:00Z",
+    "comments": [
+      {
+        "id": "C07A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-11T09:00:00Z",
+        "children": [
+          {
+            "id": "C07B",
+            "nickname": "패션몽타주",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-11T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C07C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-12T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-008",
+    "title": "자전거 출퇴근 1년차 리포트",
+    "nickname": "페달매니아",
+    "summary": "1년 동안 자전거로 출퇴근하며 얻은 팁을 공유합니다.",
+    "content": "<h2>자전거 출퇴근 1년차 리포트</h2><p>1년 동안 자전거로 출퇴근하며 얻은 팁을 공유합니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/7.jpeg",
+    "attachments": [
+      "assets/pics/1.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#08"
+    ],
+    "views": 225,
+    "likes": 54,
+    "dislikes": 2,
+    "createdAt": "2024-01-12T09:00:00Z",
+    "updatedAt": "2024-01-12T21:00:00Z",
+    "comments": [
+      {
+        "id": "C08A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-12T09:00:00Z",
+        "children": [
+          {
+            "id": "C08B",
+            "nickname": "페달매니아",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-12T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C08C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-13T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-009",
+    "title": "공정무역 커피 탐방",
+    "nickname": "공정러버",
+    "summary": "공정무역 커피 생산지를 방문하고 느낀 점입니다.",
+    "content": "<h2>공정무역 커피 탐방</h2><p>공정무역 커피 생산지를 방문하고 느낀 점입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/8.webp",
+    "attachments": [
+      "assets/pics/2.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#09"
+    ],
+    "views": 240,
+    "likes": 56,
+    "dislikes": 3,
+    "createdAt": "2024-01-13T09:00:00Z",
+    "updatedAt": "2024-01-13T21:00:00Z",
+    "comments": [
+      {
+        "id": "C09A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-13T09:00:00Z",
+        "children": [
+          {
+            "id": "C09B",
+            "nickname": "공정러버",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-13T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C09C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-14T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-010",
+    "title": "도시 양봉의 매력",
+    "nickname": "꿀벌대장",
+    "summary": "도시에서 양봉을 시작하며 배우고 느낀 점을 적었습니다.",
+    "content": "<h2>도시 양봉의 매력</h2><p>도시에서 양봉을 시작하며 배우고 느낀 점을 적었습니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/9.webp",
+    "attachments": [
+      "assets/pics/3.png"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#10"
+    ],
+    "views": 255,
+    "likes": 58,
+    "dislikes": 4,
+    "createdAt": "2024-01-14T09:00:00Z",
+    "updatedAt": "2024-01-14T21:00:00Z",
+    "comments": [
+      {
+        "id": "C10A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-14T09:00:00Z",
+        "children": [
+          {
+            "id": "C10B",
+            "nickname": "꿀벌대장",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-14T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C10C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-15T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-011",
+    "title": "우리가 사랑한 로컬 푸드",
+    "nickname": "향기나는밥상",
+    "summary": "로컬 푸드를 활용한 요리와 생산자 이야기를 정리했습니다.",
+    "content": "<h2>우리가 사랑한 로컬 푸드</h2><p>로컬 푸드를 활용한 요리와 생산자 이야기를 정리했습니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/1.jpg",
+    "attachments": [
+      "assets/pics/4.gif"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#11"
+    ],
+    "views": 270,
+    "likes": 60,
+    "dislikes": 0,
+    "createdAt": "2024-01-15T09:00:00Z",
+    "updatedAt": "2024-01-15T21:00:00Z",
+    "comments": [
+      {
+        "id": "C11A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-15T09:00:00Z",
+        "children": [
+          {
+            "id": "C11B",
+            "nickname": "향기나는밥상",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-15T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C11C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-16T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-012",
+    "title": "학교 텃밭 프로젝트",
+    "nickname": "씨앗선생",
+    "summary": "학생들과 함께 운영한 텃밭 프로젝트 성과입니다.",
+    "content": "<h2>학교 텃밭 프로젝트</h2><p>학생들과 함께 운영한 텃밭 프로젝트 성과입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/2.jpg",
+    "attachments": [
+      "assets/pics/5.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#12"
+    ],
+    "views": 285,
+    "likes": 62,
+    "dislikes": 1,
+    "createdAt": "2024-01-16T09:00:00Z",
+    "updatedAt": "2024-01-16T21:00:00Z",
+    "comments": [
+      {
+        "id": "C12A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-16T09:00:00Z",
+        "children": [
+          {
+            "id": "C12B",
+            "nickname": "씨앗선생",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-16T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C12C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-17T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-013",
+    "title": "바다 살리기 기부 캠페인",
+    "nickname": "물결나눔",
+    "summary": "바다 살리기 캠페인을 준비하며 모금한 활동기입니다.",
+    "content": "<h2>바다 살리기 기부 캠페인</h2><p>바다 살리기 캠페인을 준비하며 모금한 활동기입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/3.png",
+    "attachments": [
+      "assets/pics/5.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#13"
+    ],
+    "views": 300,
+    "likes": 64,
+    "dislikes": 2,
+    "createdAt": "2024-01-17T09:00:00Z",
+    "updatedAt": "2024-01-17T21:00:00Z",
+    "comments": [
+      {
+        "id": "C13A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-17T09:00:00Z",
+        "children": [
+          {
+            "id": "C13B",
+            "nickname": "물결나눔",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-17T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C13C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-18T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-014",
+    "title": "기후 위기 강연 후기",
+    "nickname": "바람해설가",
+    "summary": "기후 위기 강연을 듣고 정리한 핵심 메시지입니다.",
+    "content": "<h2>기후 위기 강연 후기</h2><p>기후 위기 강연을 듣고 정리한 핵심 메시지입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/4.gif",
+    "attachments": [
+      "assets/pics/6.jpeg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#14"
+    ],
+    "views": 315,
+    "likes": 66,
+    "dislikes": 3,
+    "createdAt": "2024-01-18T09:00:00Z",
+    "updatedAt": "2024-01-18T21:00:00Z",
+    "comments": [
+      {
+        "id": "C14A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-18T09:00:00Z",
+        "children": [
+          {
+            "id": "C14B",
+            "nickname": "바람해설가",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-18T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C14C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-19T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-015",
+    "title": "아이와 함께한 업사이클링",
+    "nickname": "달빛별빛",
+    "summary": "아이와 함께 진행한 업사이클링 체험 수업 후기입니다.",
+    "content": "<h2>아이와 함께한 업사이클링</h2><p>아이와 함께 진행한 업사이클링 체험 수업 후기입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/5.jpg",
+    "attachments": [
+      "assets/pics/7.jpeg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#15"
+    ],
+    "views": 330,
+    "likes": 68,
+    "dislikes": 4,
+    "createdAt": "2024-01-19T09:00:00Z",
+    "updatedAt": "2024-01-19T21:00:00Z",
+    "comments": [
+      {
+        "id": "C15A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-19T09:00:00Z",
+        "children": [
+          {
+            "id": "C15B",
+            "nickname": "달빛별빛",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-19T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C15C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-20T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-016",
+    "title": "ESG 경영 스터디 노트",
+    "nickname": "그린리더",
+    "summary": "ESG 경영 스터디에서 다룬 케이스를 공유합니다.",
+    "content": "<h2>ESG 경영 스터디 노트</h2><p>ESG 경영 스터디에서 다룬 케이스를 공유합니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/5.webp",
+    "attachments": [
+      "assets/pics/8.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#16"
+    ],
+    "views": 345,
+    "likes": 70,
+    "dislikes": 0,
+    "createdAt": "2024-01-20T09:00:00Z",
+    "updatedAt": "2024-01-20T21:00:00Z",
+    "comments": [
+      {
+        "id": "C16A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-20T09:00:00Z",
+        "children": [
+          {
+            "id": "C16B",
+            "nickname": "그린리더",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-20T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C16C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-21T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-017",
+    "title": "자연친화 에코 하우스",
+    "nickname": "흙집연구소",
+    "summary": "자연친화적인 집을 짓는 과정을 소개합니다.",
+    "content": "<h2>자연친화 에코 하우스</h2><p>자연친화적인 집을 짓는 과정을 소개합니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/6.jpeg",
+    "attachments": [
+      "assets/pics/9.webp"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#17"
+    ],
+    "views": 360,
+    "likes": 72,
+    "dislikes": 1,
+    "createdAt": "2024-01-21T09:00:00Z",
+    "updatedAt": "2024-01-21T21:00:00Z",
+    "comments": [
+      {
+        "id": "C17A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-21T09:00:00Z",
+        "children": [
+          {
+            "id": "C17B",
+            "nickname": "흙집연구소",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-21T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C17C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-22T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-018",
+    "title": "한강 생태 탐사",
+    "nickname": "강바람",
+    "summary": "한강 생태계를 탐사하며 기록한 관찰일지입니다.",
+    "content": "<h2>한강 생태 탐사</h2><p>한강 생태계를 탐사하며 기록한 관찰일지입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/7.jpeg",
+    "attachments": [
+      "assets/pics/1.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#18"
+    ],
+    "views": 375,
+    "likes": 74,
+    "dislikes": 2,
+    "createdAt": "2024-01-22T09:00:00Z",
+    "updatedAt": "2024-01-22T21:00:00Z",
+    "comments": [
+      {
+        "id": "C18A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-22T09:00:00Z",
+        "children": [
+          {
+            "id": "C18B",
+            "nickname": "강바람",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-22T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C18C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-23T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-019",
+    "title": "탄소중립 여행기",
+    "nickname": "여행노마드",
+    "summary": "탄소중립 여행을 위한 준비와 여정기를 담았습니다.",
+    "content": "<h2>탄소중립 여행기</h2><p>탄소중립 여행을 위한 준비와 여정기를 담았습니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/8.webp",
+    "attachments": [
+      "assets/pics/2.jpg"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#19"
+    ],
+    "views": 390,
+    "likes": 76,
+    "dislikes": 3,
+    "createdAt": "2024-01-23T09:00:00Z",
+    "updatedAt": "2024-01-23T21:00:00Z",
+    "comments": [
+      {
+        "id": "C19A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-23T09:00:00Z",
+        "children": [
+          {
+            "id": "C19B",
+            "nickname": "여행노마드",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-23T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C19C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-24T12:00:00Z",
+        "children": []
+      }
+    ]
+  },
+  {
+    "id": "POST-020",
+    "title": "제로 에너지 마을 방문기",
+    "nickname": "태양마을기자",
+    "summary": "제로 에너지 마을을 방문하고 느낀 인사이트입니다.",
+    "content": "<h2>제로 에너지 마을 방문기</h2><p>제로 에너지 마을을 방문하고 느낀 인사이트입니다.</p><p>현장에서 촬영한 사진과 데이터를 정리해 공유합니다. 활동에 참여하고 싶은 분들은 댓글로 의견 남겨주세요!</p>",
+    "thumbnail": "assets/pics/9.webp",
+    "attachments": [
+      "assets/pics/3.png"
+    ],
+    "tags": [
+      "환경",
+      "커뮤니티",
+      "실천",
+      "#20"
+    ],
+    "views": 405,
+    "likes": 78,
+    "dislikes": 4,
+    "createdAt": "2024-01-24T09:00:00Z",
+    "updatedAt": "2024-01-24T21:00:00Z",
+    "comments": [
+      {
+        "id": "C20A",
+        "nickname": "에코프렌즈",
+        "content": "<p>정말 멋진 도전이에요! 사진만 봐도 에너지가 느껴집니다.</p>",
+        "createdAt": "2024-01-24T09:00:00Z",
+        "children": [
+          {
+            "id": "C20B",
+            "nickname": "태양마을기자",
+            "content": "<p>응원 감사합니다! 다음에는 함께해요 :)</p>",
+            "createdAt": "2024-01-24T15:00:00Z",
+            "children": []
+          }
+        ]
+      },
+      {
+        "id": "C20C",
+        "nickname": "녹색추적자",
+        "content": "<p>자료 공유 가능할까요? 커뮤니티에도 소개하고 싶어요.</p>",
+        "createdAt": "2024-01-25T12:00:00Z",
+        "children": []
+      }
+    ]
+  }
+]

--- a/lib/app/app_root.dart
+++ b/lib/app/app_root.dart
@@ -9,6 +9,8 @@ import 'package:untitled3/features/auth/controllers/auth_controller.dart';
 import 'package:untitled3/features/auth/data/dummy_user_repository.dart';
 import 'package:untitled3/features/auth/services/crypto_service.dart';
 import 'package:untitled3/features/auth/services/metamask_connector.dart';
+import 'package:untitled3/features/board/controllers/board_controller.dart';
+import 'package:untitled3/features/board/data/asset_user_post_repository.dart';
 import 'navigation/navigation_controller.dart';
 import 'router/app_router.dart';
 
@@ -37,6 +39,9 @@ class _AppRootState extends State<AppRoot> {
         Provider<MetamaskConnector>(
           create: (_) => MetamaskConnector.secure(),
         ),
+        Provider<UserPostRepository>(
+          create: (_) => AssetUserPostRepository(),
+        ),
         ChangeNotifierProvider<NavigationController>(
           create: (_) => NavigationController(),
         ),
@@ -44,6 +49,11 @@ class _AppRootState extends State<AppRoot> {
           create: (context) => AuthController(
             userRepository: context.read<DummyUserRepository>(),
             metamaskConnector: context.read<MetamaskConnector>(),
+          ),
+        ),
+        ChangeNotifierProvider<BoardController>(
+          create: (context) => BoardController(
+            repository: context.read<UserPostRepository>(),
           ),
         ),
       ],

--- a/lib/app/navigation/adaptive_navigation_shell.dart
+++ b/lib/app/navigation/adaptive_navigation_shell.dart
@@ -84,7 +84,15 @@ class AdaptiveNavigationShell extends StatelessWidget {
 
   String _titleForRoute(String location) {
     final match = appDestinations.firstWhere(
-      (destination) => destination.location == location,
+      (destination) {
+        if (destination.location == location) {
+          return true;
+        }
+        if (destination.location == '/') {
+          return false;
+        }
+        return location.startsWith('${destination.location}/');
+      },
       orElse: () => appDestinations.first,
     );
     return match.label;

--- a/lib/app/navigation/app_destinations.dart
+++ b/lib/app/navigation/app_destinations.dart
@@ -2,6 +2,7 @@
 // 파일 설명: 어댑티브 셸 라우터에서 사용할 목적지를 정의.
 import 'package:flutter/material.dart';
 import 'package:untitled3/features/auth/view/login_page.dart';
+import 'package:untitled3/features/board/view/board_page.dart';
 import 'package:untitled3/features/simple_page/simple_page.dart';
 
 class AppDestination {
@@ -40,7 +41,7 @@ final List<AppDestination> appDestinations = [
     name: 'free',
     label: '자유',
     icon: Icons.forum_outlined,
-    builder: (_) => const SimplePage(message: '자유 게시판이 준비 중입니다.'),
+    builder: (_) => const BoardPage(),
   ),
   AppDestination(
     location: '/experiment',

--- a/lib/app/navigation/navigation_controller.dart
+++ b/lib/app/navigation/navigation_controller.dart
@@ -25,7 +25,15 @@ class NavigationController extends ChangeNotifier {
     }
     _location = location;
     final matchIndex = appDestinations.indexWhere(
-      (destination) => destination.location == location,
+      (destination) {
+        if (destination.location == location) {
+          return true;
+        }
+        if (destination.location == '/') {
+          return false;
+        }
+        return location.startsWith('${destination.location}/');
+      },
     );
     if (matchIndex != -1 && matchIndex != _selectedIndex) {
       _selectedIndex = matchIndex;

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -2,6 +2,9 @@
 // 파일 설명: 애플리케이션 셸에서 사용할 라우터 구성을 정의.
 
 import 'package:go_router/go_router.dart';
+import 'package:untitled3/features/board/view/post_detail_page.dart';
+import 'package:untitled3/features/board/view/post_editor_page.dart';
+
 import '../navigation/adaptive_navigation_shell.dart';
 import '../navigation/app_destinations.dart';
 
@@ -26,6 +29,34 @@ class AppRouter {
                 child: destination.builder(context),
               ),
             ),
+          GoRoute(
+            path: '/free/new',
+            name: 'postNew',
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: const PostEditorPage(),
+            ),
+          ),
+          GoRoute(
+            path: '/free/post/:id',
+            name: 'postDetail',
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: PostDetailPage(
+                postId: state.pathParameters['id']!,
+              ),
+            ),
+          ),
+          GoRoute(
+            path: '/free/post/:id/edit',
+            name: 'postEdit',
+            pageBuilder: (context, state) => NoTransitionPage(
+              key: state.pageKey,
+              child: PostEditorPage(
+                postId: state.pathParameters['id']!,
+              ),
+            ),
+          ),
         ],
       ),
     ],

--- a/lib/features/board/controllers/board_controller.dart
+++ b/lib/features/board/controllers/board_controller.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/foundation.dart';
+
+import '../data/asset_user_post_repository.dart';
+import '../models/post_comment.dart';
+import '../models/user_post.dart';
+
+class BoardController extends ChangeNotifier {
+  BoardController({required this.repository});
+
+  final UserPostRepository repository;
+
+  List<UserPost> _posts = const [];
+  bool _isLoading = false;
+  bool _hasLoaded = false;
+  String? _errorMessage;
+  PostLayoutMode _layoutMode = PostLayoutMode.list;
+
+  List<UserPost> get posts => _posts;
+  bool get isLoading => _isLoading;
+  bool get hasLoaded => _hasLoaded;
+  String? get errorMessage => _errorMessage;
+  PostLayoutMode get layoutMode => _layoutMode;
+
+  Future<void> loadPosts() async {
+    if (_isLoading || _hasLoaded) {
+      return;
+    }
+    _isLoading = true;
+    _errorMessage = null;
+    notifyListeners();
+    try {
+      final fetchedPosts = await repository.fetchPosts();
+      _posts = List.unmodifiable(fetchedPosts);
+      _hasLoaded = true;
+    } catch (error) {
+      _errorMessage = '게시글을 불러오지 못했습니다. 다시 시도해 주세요.';
+      debugPrint('BoardController.loadPosts error: $error');
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  void changeLayout(PostLayoutMode mode) {
+    if (_layoutMode == mode) {
+      return;
+    }
+    _layoutMode = mode;
+    notifyListeners();
+  }
+
+  void addPost(UserPost post) {
+    _posts = List.unmodifiable(<UserPost>[post, ..._posts]);
+    notifyListeners();
+  }
+
+  void updatePost(UserPost updatedPost) {
+    final index = _posts.indexWhere((post) => post.id == updatedPost.id);
+    if (index == -1) {
+      return;
+    }
+    final mutable = List<UserPost>.from(_posts);
+    mutable[index] = updatedPost;
+    _posts = List.unmodifiable(mutable);
+    notifyListeners();
+  }
+
+  void deletePost(String postId) {
+    _posts = List.unmodifiable(
+      _posts.where((post) => post.id != postId),
+    );
+    notifyListeners();
+  }
+
+  UserPost? findPostById(String postId) {
+    return _posts.firstWhereOrNull((post) => post.id == postId);
+  }
+
+  void recordView(String postId) {
+    final post = findPostById(postId);
+    if (post == null) {
+      return;
+    }
+    updatePost(post.copyWith(views: post.views + 1));
+  }
+
+  void toggleLike(String postId, {required bool isLike}) {
+    final post = findPostById(postId);
+    if (post == null) {
+      return;
+    }
+    if (isLike) {
+      updatePost(post.copyWith(likes: post.likes + 1));
+    } else {
+      updatePost(post.copyWith(dislikes: post.dislikes + 1));
+    }
+  }
+
+  void addComment(
+    String postId,
+    PostComment comment, {
+    String? parentId,
+  }) {
+    final post = findPostById(postId);
+    if (post == null) {
+      return;
+    }
+    final updatedComments = _addCommentToTree(post.comments, parentId, comment);
+    updatePost(post.copyWith(comments: updatedComments));
+  }
+
+  void deleteComment(String postId, String commentId) {
+    final post = findPostById(postId);
+    if (post == null) {
+      return;
+    }
+    final updatedComments =
+        _removeCommentFromTree(post.comments, commentId).toList();
+    updatePost(post.copyWith(comments: updatedComments));
+  }
+
+  List<PostComment> _addCommentToTree(
+    List<PostComment> comments,
+    String? parentId,
+    PostComment newComment,
+  ) {
+    if (parentId == null) {
+      return <PostComment>[newComment, ...comments];
+    }
+    return comments
+        .map((comment) {
+          if (comment.id == parentId) {
+            final replies = <PostComment>[newComment, ...comment.children];
+            return comment.copyWith(children: replies);
+          }
+          if (comment.children.isEmpty) {
+            return comment;
+          }
+          final updatedChildren =
+              _addCommentToTree(comment.children, parentId, newComment);
+          if (!listEquals(comment.children, updatedChildren)) {
+            return comment.copyWith(children: updatedChildren);
+          }
+          return comment;
+        })
+        .toList(growable: false);
+  }
+
+  Iterable<PostComment> _removeCommentFromTree(
+    List<PostComment> comments,
+    String commentId,
+  ) sync* {
+    for (final comment in comments) {
+      if (comment.id == commentId) {
+        continue;
+      }
+      if (comment.children.isEmpty) {
+        yield comment;
+        continue;
+      }
+      final updatedChildren =
+          _removeCommentFromTree(comment.children, commentId).toList();
+      if (!listEquals(comment.children, updatedChildren)) {
+        yield comment.copyWith(children: updatedChildren);
+      } else {
+        yield comment;
+      }
+    }
+  }
+}
+
+extension<T> on Iterable<T> {
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (final element in this) {
+      if (test(element)) {
+        return element;
+      }
+    }
+    return null;
+  }
+}

--- a/lib/features/board/data/asset_user_post_repository.dart
+++ b/lib/features/board/data/asset_user_post_repository.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+import '../models/user_post.dart';
+
+abstract class UserPostRepository {
+  Future<List<UserPost>> fetchPosts();
+}
+
+class AssetUserPostRepository implements UserPostRepository {
+  AssetUserPostRepository({
+    this.assetPath = 'assets/data/user_posts.json',
+  });
+
+  final String assetPath;
+
+  @override
+  Future<List<UserPost>> fetchPosts() async {
+    final jsonString = await rootBundle.loadString(assetPath);
+    final List<dynamic> rawList = json.decode(jsonString) as List<dynamic>;
+    return rawList
+        .map((item) => UserPost.fromJson(item as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/features/board/models/post_comment.dart
+++ b/lib/features/board/models/post_comment.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/foundation.dart';
+
+class PostComment {
+  PostComment({
+    required this.id,
+    required this.nickname,
+    required this.content,
+    required this.createdAt,
+    List<PostComment>? children,
+  }) : children = List.unmodifiable(children ?? const []);
+
+  factory PostComment.fromJson(Map<String, dynamic> json) {
+    return PostComment(
+      id: json['id'] as String,
+      nickname: json['nickname'] as String,
+      content: json['content'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      children: (json['children'] as List<dynamic>?)
+          ?.map((child) => PostComment.fromJson(child as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  final String id;
+  final String nickname;
+  final String content;
+  final DateTime createdAt;
+  final List<PostComment> children;
+
+  PostComment copyWith({
+    String? id,
+    String? nickname,
+    String? content,
+    DateTime? createdAt,
+    List<PostComment>? children,
+  }) {
+    return PostComment(
+      id: id ?? this.id,
+      nickname: nickname ?? this.nickname,
+      content: content ?? this.content,
+      createdAt: createdAt ?? this.createdAt,
+      children: children ?? this.children,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'nickname': nickname,
+      'content': content,
+      'createdAt': createdAt.toIso8601String(),
+      'children': children.map((child) => child.toJson()).toList(),
+    };
+  }
+
+  @override
+  String toString() =>
+      'PostComment(id: $id, nickname: $nickname, replies: ${children.length})';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PostComment &&
+          id == other.id &&
+          nickname == other.nickname &&
+          content == other.content &&
+          createdAt == other.createdAt &&
+          listEquals(children, other.children);
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        nickname,
+        content,
+        createdAt,
+        Object.hashAll(children),
+      );
+}

--- a/lib/features/board/models/user_post.dart
+++ b/lib/features/board/models/user_post.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/foundation.dart';
+
+import 'post_comment.dart';
+
+enum PostLayoutMode { list, gallery }
+
+class UserPost {
+  UserPost({
+    required this.id,
+    required this.title,
+    required this.nickname,
+    required this.summary,
+    required this.content,
+    required this.thumbnail,
+    required this.attachments,
+    required this.tags,
+    required this.views,
+    required this.likes,
+    required this.dislikes,
+    required this.createdAt,
+    required this.updatedAt,
+    List<PostComment>? comments,
+  }) : comments = List.unmodifiable(comments ?? const []);
+
+  factory UserPost.fromJson(Map<String, dynamic> json) {
+    return UserPost(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      nickname: json['nickname'] as String,
+      summary: json['summary'] as String,
+      content: json['content'] as String,
+      thumbnail: json['thumbnail'] as String,
+      attachments: (json['attachments'] as List<dynamic>?)
+              ?.map((item) => item as String)
+              .toList() ??
+          const <String>[],
+      tags: (json['tags'] as List<dynamic>?)
+              ?.map((item) => item as String)
+              .toList() ??
+          const <String>[],
+      views: json['views'] as int,
+      likes: json['likes'] as int,
+      dislikes: json['dislikes'] as int,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      comments: (json['comments'] as List<dynamic>?)
+              ?.map((comment) =>
+                  PostComment.fromJson(comment as Map<String, dynamic>))
+              .toList() ??
+          const <PostComment>[],
+    );
+  }
+
+  final String id;
+  final String title;
+  final String nickname;
+  final String summary;
+  final String content;
+  final String thumbnail;
+  final List<String> attachments;
+  final List<String> tags;
+  final int views;
+  final int likes;
+  final int dislikes;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final List<PostComment> comments;
+
+  String get sharePath => '/free/post/$id';
+
+  String get plainSummary =>
+      summary.replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), '').trim();
+
+  UserPost copyWith({
+    String? id,
+    String? title,
+    String? nickname,
+    String? summary,
+    String? content,
+    String? thumbnail,
+    List<String>? attachments,
+    List<String>? tags,
+    int? views,
+    int? likes,
+    int? dislikes,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    List<PostComment>? comments,
+  }) {
+    return UserPost(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      nickname: nickname ?? this.nickname,
+      summary: summary ?? this.summary,
+      content: content ?? this.content,
+      thumbnail: thumbnail ?? this.thumbnail,
+      attachments: attachments ?? this.attachments,
+      tags: tags ?? this.tags,
+      views: views ?? this.views,
+      likes: likes ?? this.likes,
+      dislikes: dislikes ?? this.dislikes,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      comments: comments ?? this.comments,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return <String, dynamic>{
+      'id': id,
+      'title': title,
+      'nickname': nickname,
+      'summary': summary,
+      'content': content,
+      'thumbnail': thumbnail,
+      'attachments': attachments,
+      'tags': tags,
+      'views': views,
+      'likes': likes,
+      'dislikes': dislikes,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+      'comments': comments.map((comment) => comment.toJson()).toList(),
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserPost &&
+          id == other.id &&
+          title == other.title &&
+          nickname == other.nickname &&
+          summary == other.summary &&
+          content == other.content &&
+          thumbnail == other.thumbnail &&
+          listEquals(attachments, other.attachments) &&
+          listEquals(tags, other.tags) &&
+          views == other.views &&
+          likes == other.likes &&
+          dislikes == other.dislikes &&
+          createdAt == other.createdAt &&
+          updatedAt == other.updatedAt &&
+          listEquals(comments, other.comments);
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        title,
+        nickname,
+        summary,
+        content,
+        thumbnail,
+        Object.hashAll(attachments),
+        Object.hashAll(tags),
+        views,
+        likes,
+        dislikes,
+        createdAt,
+        updatedAt,
+        Object.hashAll(comments),
+      );
+}

--- a/lib/features/board/view/board_page.dart
+++ b/lib/features/board/view/board_page.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/board_controller.dart';
+import '../models/user_post.dart';
+import '../widgets/post_gallery_view.dart';
+import '../widgets/post_list_view.dart';
+
+class BoardPage extends StatefulWidget {
+  const BoardPage({super.key});
+
+  @override
+  State<BoardPage> createState() => _BoardPageState();
+}
+
+class _BoardPageState extends State<BoardPage> {
+  bool _requested = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_requested) {
+      _requested = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        context.read<BoardController>().loadPosts();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<BoardController>();
+    final posts = controller.posts;
+
+    final toggle = SegmentedButton<PostLayoutMode>(
+      segments: const <ButtonSegment<PostLayoutMode>>[
+        ButtonSegment<PostLayoutMode>(
+          value: PostLayoutMode.list,
+          label: Text('리스트'),
+          icon: Icon(Icons.view_list),
+        ),
+        ButtonSegment<PostLayoutMode>(
+          value: PostLayoutMode.gallery,
+          label: Text('갤러리'),
+          icon: Icon(Icons.grid_view),
+        ),
+      ],
+      selected: <PostLayoutMode>{controller.layoutMode},
+      onSelectionChanged: (selection) {
+        controller.changeLayout(selection.first);
+      },
+    );
+
+    Widget content;
+    if (controller.isLoading && !controller.hasLoaded) {
+      content = const Center(child: CircularProgressIndicator());
+    } else if (controller.errorMessage != null) {
+      content = Center(child: Text(controller.errorMessage!));
+    } else if (posts.isEmpty) {
+      content = const _EmptyPlaceholder();
+    } else {
+      content = AnimatedSwitcher(
+        duration: const Duration(milliseconds: 250),
+        child: controller.layoutMode == PostLayoutMode.list
+            ? PostListView(
+                key: const ValueKey('list-view'),
+                posts: posts,
+                onTap: _openDetail,
+                onShare: _sharePost,
+                onReaction: _handleReaction,
+              )
+            : PostGalleryView(
+                key: const ValueKey('gallery-view'),
+                posts: posts,
+                onTap: _openDetail,
+                onShare: _sharePost,
+                onReaction: _handleReaction,
+              ),
+      );
+    }
+
+    return Scaffold(
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => context.push('/free/new'),
+        icon: const Icon(Icons.edit),
+        label: const Text('글 작성'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Text(
+                    '커뮤니티 게시판',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .primaryContainer
+                          .withOpacity(0.6),
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    child: Text(
+                      '${posts.length}개의 게시글',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onPrimaryContainer,
+                          ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  toggle,
+                ],
+              ),
+              const SizedBox(height: 20),
+              Expanded(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(18),
+                    border: Border.all(
+                      color: Theme.of(context).colorScheme.outlineVariant,
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: content,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openDetail(UserPost post) {
+    context.push('/free/post/${post.id}', extra: post);
+  }
+
+  void _handleReaction(UserPost post, bool isLike) {
+    final controller = context.read<BoardController>();
+    controller.toggleLike(post.id, isLike: isLike);
+  }
+
+  Future<void> _sharePost(UserPost post) async {
+    final base = Uri.base;
+    final target = base.replace(path: post.sharePath).toString();
+    await Clipboard.setData(ClipboardData(text: target));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('공유 링크가 복사되었습니다.\n$target'),
+      ),
+    );
+  }
+}
+
+class _EmptyPlaceholder extends StatelessWidget {
+  const _EmptyPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.chat_bubble_outline,
+            size: 48,
+            color: Theme.of(context).colorScheme.outline,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            '아직 등록된 게시글이 없습니다.',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '첫 번째 글의 주인공이 되어보세요!',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/board/view/post_detail_page.dart
+++ b/lib/features/board/view/post_detail_page.dart
@@ -1,0 +1,335 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/board_controller.dart';
+import '../models/post_comment.dart';
+import '../models/user_post.dart';
+import '../widgets/comment_thread.dart';
+import '../widgets/post_meta_row.dart';
+
+class PostDetailPage extends StatefulWidget {
+  const PostDetailPage({
+    required this.postId,
+    super.key,
+  });
+
+  final String postId;
+
+  @override
+  State<PostDetailPage> createState() => _PostDetailPageState();
+}
+
+class _PostDetailPageState extends State<PostDetailPage> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<BoardController>().recordView(widget.postId);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<BoardController>();
+    final post = controller.findPostById(widget.postId);
+    if (post == null) {
+      return Scaffold(
+        body: Center(
+          child: Text(
+            '게시글을 찾을 수 없습니다.',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+      );
+    }
+
+    final dateFormat = DateFormat('yyyy년 MM월 dd일 HH:mm');
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          post.title,
+                          style: Theme.of(context).textTheme.headlineSmall,
+                        ),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            Chip(
+                              avatar: const Icon(Icons.person_outline),
+                              label: Text(post.nickname),
+                            ),
+                            Text('작성 ${dateFormat.format(post.createdAt)}'),
+                            Text('수정 ${dateFormat.format(post.updatedAt)}'),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Column(
+                    children: [
+                      IconButton(
+                        onPressed: () => _sharePost(post),
+                        icon: const Icon(Icons.share_outlined),
+                        tooltip: '공유',
+                      ),
+                      const SizedBox(height: 8),
+                      FilledButton.tonalIcon(
+                        onPressed: () {
+                          context.push('/free/post/${post.id}/edit', extra: post);
+                        },
+                        icon: const Icon(Icons.edit_outlined),
+                        label: const Text('수정'),
+                      ),
+                      const SizedBox(height: 8),
+                      OutlinedButton.icon(
+                        onPressed: () => _confirmDelete(post),
+                        icon: const Icon(Icons.delete_outline),
+                        label: const Text('삭제'),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              if (post.tags.isNotEmpty)
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    for (final tag in post.tags)
+                      Chip(
+                        label: Text(tag),
+                        backgroundColor: Theme.of(context)
+                            .colorScheme
+                            .primaryContainer
+                            .withOpacity(0.3),
+                      ),
+                  ],
+                ),
+              const SizedBox(height: 20),
+              if (post.thumbnail.isNotEmpty)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: Image.asset(
+                    post.thumbnail,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              const SizedBox(height: 20),
+              Html(data: post.content),
+              const SizedBox(height: 12),
+              if (post.attachments.isNotEmpty)
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '첨부 이미지',
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 12,
+                      runSpacing: 12,
+                      children: [
+                        for (final attachment in post.attachments)
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(12),
+                            child: Image.asset(
+                              attachment,
+                              width: 160,
+                              height: 120,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                      ],
+                    ),
+                  ],
+                ),
+              const SizedBox(height: 24),
+              PostMetaRow(
+                post: post,
+                onReaction: (isLike) {
+                  controller.toggleLike(post.id, isLike: isLike);
+                },
+              ),
+              const Divider(height: 48),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    '댓글 ${_countComments(post.comments)}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  FilledButton.icon(
+                    onPressed: () => _openCommentDialog(post),
+                    icon: const Icon(Icons.add_comment),
+                    label: const Text('댓글 작성'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              CommentThread(
+                comments: post.comments,
+                onReply: (comment) => _openCommentDialog(post, parent: comment),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _sharePost(UserPost post) async {
+    final target = Uri.base.replace(path: post.sharePath).toString();
+    await Clipboard.setData(ClipboardData(text: target));
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('공유 링크가 복사되었습니다.\n$target')),
+    );
+  }
+
+  Future<void> _confirmDelete(UserPost post) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('게시글 삭제'),
+          content: const Text('삭제된 게시글은 되돌릴 수 없습니다. 삭제하시겠습니까?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('취소'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('삭제'),
+            ),
+          ],
+        );
+      },
+    );
+    if (confirmed != true) {
+      return;
+    }
+    context.read<BoardController>().deletePost(post.id);
+    if (!mounted) {
+      return;
+    }
+    context.go('/free');
+  }
+
+  Future<void> _openCommentDialog(
+    UserPost post, {
+    PostComment? parent,
+  }) async {
+    final nicknameController = TextEditingController();
+    final contentController = TextEditingController();
+    final result = await showDialog<_CommentDialogResult>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(parent == null ? '새 댓글 작성' : '답글 작성'),
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nicknameController,
+                  decoration: const InputDecoration(
+                    labelText: '닉네임',
+                  ),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: contentController,
+                  decoration: const InputDecoration(
+                    labelText: '내용',
+                  ),
+                  minLines: 4,
+                  maxLines: 6,
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('취소'),
+            ),
+            FilledButton(
+              onPressed: () {
+                if (nicknameController.text.trim().isEmpty ||
+                    contentController.text.trim().isEmpty) {
+                  return;
+                }
+                Navigator.of(context).pop(
+                  _CommentDialogResult(
+                    nickname: nicknameController.text.trim(),
+                    content: contentController.text.trim(),
+                  ),
+                );
+              },
+              child: const Text('등록'),
+            ),
+          ],
+        );
+      },
+    );
+    if (result == null) {
+      return;
+    }
+    final now = DateTime.now();
+    final escapedContent = const HtmlEscape().convert(result.content);
+    final formattedContent = '<p>${escapedContent.replaceAll('\n', '<br />')}</p>';
+    final newComment = PostComment(
+      id: 'C${now.millisecondsSinceEpoch}',
+      nickname: result.nickname,
+      content: formattedContent,
+      createdAt: now,
+      children: const [],
+    );
+    context
+        .read<BoardController>()
+        .addComment(post.id, newComment, parentId: parent?.id);
+  }
+
+  int _countComments(List<PostComment> comments) {
+    var total = 0;
+    for (final comment in comments) {
+      total += 1 + _countComments(comment.children);
+    }
+    return total;
+  }
+}
+
+class _CommentDialogResult {
+  const _CommentDialogResult({
+    required this.nickname,
+    required this.content,
+  });
+
+  final String nickname;
+  final String content;
+}

--- a/lib/features/board/view/post_editor_page.dart
+++ b/lib/features/board/view/post_editor_page.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import '../controllers/board_controller.dart';
+import '../models/user_post.dart';
+import '../../../util/editor/ckeditor_field.dart';
+
+const List<String> kAvailableImages = [
+  'assets/pics/1.jpg',
+  'assets/pics/2.jpg',
+  'assets/pics/3.png',
+  'assets/pics/4.gif',
+  'assets/pics/5.jpg',
+  'assets/pics/5.webp',
+  'assets/pics/6.jpeg',
+  'assets/pics/7.jpeg',
+  'assets/pics/8.webp',
+  'assets/pics/9.webp',
+];
+
+class PostEditorPage extends StatefulWidget {
+  const PostEditorPage({
+    this.postId,
+    super.key,
+  });
+
+  final String? postId;
+
+  @override
+  State<PostEditorPage> createState() => _PostEditorPageState();
+}
+
+class _PostEditorPageState extends State<PostEditorPage> {
+  final _formKey = GlobalKey<FormState>();
+  late final BoardController _controller = context.read<BoardController>();
+  UserPost? _original;
+
+  late final TextEditingController _titleController;
+  late final TextEditingController _summaryController;
+  late final TextEditingController _nicknameController;
+  late final TextEditingController _tagsController;
+  String _thumbnail = kAvailableImages.first;
+  List<String> _attachments = <String>[];
+  String _content = '';
+
+  bool get _isEditing => widget.postId != null;
+
+  @override
+  void initState() {
+    super.initState();
+    if (_isEditing) {
+      _original = _controller.findPostById(widget.postId!);
+    }
+    _titleController = TextEditingController(text: _original?.title ?? '');
+    _summaryController = TextEditingController(text: _original?.summary ?? '');
+    _nicknameController = TextEditingController(text: _original?.nickname ?? '');
+    _tagsController = TextEditingController(
+      text: _original == null ? '' : _original!.tags.join(', '),
+    );
+    _thumbnail = _original?.thumbnail ?? _thumbnail;
+    _attachments = List<String>.from(_original?.attachments ?? <String>[]);
+    _content = _original?.content ?? '';
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _summaryController.dispose();
+    _nicknameController.dispose();
+    _tagsController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _save,
+        icon: const Icon(Icons.save_alt),
+        label: Text(_isEditing ? '글 수정' : '글 등록'),
+      ),
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+            children: [
+              Text(
+                _isEditing ? '게시글 수정' : '새 게시글 작성',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _nicknameController,
+                decoration: const InputDecoration(
+                  labelText: '작성자 닉네임',
+                  helperText: '게시글에 노출될 닉네임을 입력하세요.',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '닉네임을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: '제목',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '제목을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _summaryController,
+                maxLines: 3,
+                decoration: const InputDecoration(
+                  labelText: '요약',
+                  hintText: '목록과 갤러리에서 보여질 간단한 요약을 작성하세요.',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return '요약을 입력하세요';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              Text(
+                '대표 이미지 선택',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 120,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: kAvailableImages.length,
+                  separatorBuilder: (_, __) => const SizedBox(width: 12),
+                  itemBuilder: (context, index) {
+                    final image = kAvailableImages[index];
+                    final isSelected = image == _thumbnail;
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          _thumbnail = image;
+                        });
+                      },
+                      child: AnimatedContainer(
+                        duration: const Duration(milliseconds: 200),
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                            color: isSelected
+                                ? Theme.of(context).colorScheme.primary
+                                : Theme.of(context).colorScheme.outlineVariant,
+                            width: isSelected ? 3 : 1,
+                          ),
+                        ),
+                        width: 160,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(14),
+                          child: Image.asset(image, fit: BoxFit.cover),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                '첨부 이미지',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  for (final image in kAvailableImages)
+                    FilterChip(
+                      label: Text(image.split('/').last),
+                      avatar: Image.asset(image, width: 32, height: 32, fit: BoxFit.cover),
+                      selected: _attachments.contains(image),
+                      onSelected: (selected) {
+                        setState(() {
+                          if (selected) {
+                            _attachments = <String>{..._attachments, image}.toList();
+                          } else {
+                            _attachments = _attachments
+                                .where((attachment) => attachment != image)
+                                .toList();
+                          }
+                        });
+                      },
+                    ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: _tagsController,
+                decoration: const InputDecoration(
+                  labelText: '태그',
+                  helperText: '쉼표(,)로 구분하여 입력하세요.',
+                ),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                '본문 내용',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 12),
+              CkEditorField(
+                initialValue: _content,
+                onChanged: (value) {
+                  _content = value;
+                },
+                height: 360,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _save() {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    if (_content.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('본문 내용을 입력하세요.')),
+      );
+      return;
+    }
+    final now = DateTime.now();
+    final tags = _tagsController.text
+        .split(',')
+        .map((tag) => tag.trim())
+        .where((tag) => tag.isNotEmpty)
+        .toList();
+    final nickname = _nicknameController.text.trim();
+
+    if (_isEditing && _original != null) {
+      final updated = _original!.copyWith(
+        title: _titleController.text.trim(),
+        summary: _summaryController.text.trim(),
+        content: _content,
+        thumbnail: _thumbnail,
+        attachments: _attachments,
+        tags: tags,
+        nickname: nickname,
+        updatedAt: now,
+      );
+      _controller.updatePost(updated);
+      context.go('/free/post/${updated.id}');
+    } else {
+      final newId = 'POST-${now.millisecondsSinceEpoch}';
+      final newPost = UserPost(
+        id: newId,
+        title: _titleController.text.trim(),
+        nickname: nickname,
+        summary: _summaryController.text.trim(),
+        content: _content,
+        thumbnail: _thumbnail,
+        attachments: _attachments,
+        tags: tags,
+        views: 0,
+        likes: 0,
+        dislikes: 0,
+        createdAt: now,
+        updatedAt: now,
+        comments: const [],
+      );
+      _controller.addPost(newPost);
+      context.go('/free/post/$newId');
+    }
+  }
+}

--- a/lib/features/board/widgets/comment_thread.dart
+++ b/lib/features/board/widgets/comment_thread.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:intl/intl.dart';
+
+import '../models/post_comment.dart';
+
+class CommentThread extends StatelessWidget {
+  const CommentThread({
+    required this.comments,
+    required this.onReply,
+    super.key,
+  });
+
+  final List<PostComment> comments;
+  final void Function(PostComment comment) onReply;
+
+  @override
+  Widget build(BuildContext context) {
+    if (comments.isEmpty) {
+      return Center(
+        child: Text(
+          '첫 번째 댓글을 남겨주세요.',
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.outline,
+              ),
+        ),
+      );
+    }
+    return Column(
+      children: [
+        for (final comment in comments)
+          _CommentTile(
+            comment: comment,
+            depth: 0,
+            onReply: onReply,
+          ),
+      ],
+    );
+  }
+}
+
+class _CommentTile extends StatelessWidget {
+  const _CommentTile({
+    required this.comment,
+    required this.depth,
+    required this.onReply,
+  });
+
+  final PostComment comment;
+  final int depth;
+  final void Function(PostComment comment) onReply;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('yyyy.MM.dd HH:mm');
+    return Padding(
+      padding: EdgeInsets.only(left: depth * 16.0, bottom: 12),
+      child: Card(
+        elevation: 0,
+        color: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.6),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: BorderSide(
+            color: Theme.of(context).colorScheme.outlineVariant,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      comment.nickname,
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                  ),
+                  Text(
+                    dateFormat.format(comment.createdAt),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Html(data: comment.content),
+              Align(
+                alignment: Alignment.bottomRight,
+                child: TextButton.icon(
+                  onPressed: () => onReply(comment),
+                  icon: const Icon(Icons.reply),
+                  label: const Text('답글'),
+                ),
+              ),
+              if (comment.children.isNotEmpty)
+                for (final child in comment.children)
+                  _CommentTile(
+                    comment: child,
+                    depth: depth + 1,
+                    onReply: onReply,
+                  ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/board/widgets/post_gallery_view.dart
+++ b/lib/features/board/widgets/post_gallery_view.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/user_post.dart';
+import 'post_meta_row.dart';
+
+class PostGalleryView extends StatelessWidget {
+  const PostGalleryView({
+    required this.posts,
+    required this.onTap,
+    required this.onShare,
+    required this.onReaction,
+    super.key,
+  });
+
+  final List<UserPost> posts;
+  final ValueChanged<UserPost> onTap;
+  final Future<void> Function(UserPost post) onShare;
+  final void Function(UserPost post, bool isLike) onReaction;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        final crossAxisCount = width > 1200
+            ? 4
+            : width > 900
+                ? 3
+                : width > 600
+                    ? 2
+                    : 1;
+        return GridView.builder(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            crossAxisSpacing: 12,
+            mainAxisSpacing: 12,
+            childAspectRatio: 0.86,
+          ),
+          itemCount: posts.length,
+          itemBuilder: (context, index) {
+            final post = posts[index];
+            return _GalleryCard(
+              post: post,
+              onTap: () => onTap(post),
+              onShare: () => onShare(post),
+              onReaction: (isLike) => onReaction(post, isLike),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _GalleryCard extends StatelessWidget {
+  const _GalleryCard({
+    required this.post,
+    required this.onTap,
+    required this.onShare,
+    required this.onReaction,
+  });
+
+  final UserPost post;
+  final VoidCallback onTap;
+  final VoidCallback onShare;
+  final ValueChanged<bool> onReaction;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('MM/dd HH:mm');
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  if (post.thumbnail.isNotEmpty)
+                    Image.asset(post.thumbnail, fit: BoxFit.cover)
+                  else
+                    Container(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .primaryContainer
+                          .withOpacity(0.4),
+                      child: const Center(
+                        child: Icon(Icons.image_outlined, size: 48),
+                      ),
+                    ),
+                  Positioned(
+                    right: 8,
+                    top: 8,
+                    child: IconButton.filledTonal(
+                      onPressed: onShare,
+                      icon: const Icon(Icons.share_outlined),
+                      tooltip: '공유',
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    post.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    post.nickname,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodySmall
+                        ?.copyWith(color: Theme.of(context).colorScheme.primary),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '${dateFormat.format(post.createdAt)} · ${dateFormat.format(post.updatedAt)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    post.plainSummary,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 12),
+                  PostMetaRow(
+                    post: post,
+                    onReaction: onReaction,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/board/widgets/post_list_view.dart
+++ b/lib/features/board/widgets/post_list_view.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/user_post.dart';
+import 'post_meta_row.dart';
+
+class PostListView extends StatelessWidget {
+  const PostListView({
+    required this.posts,
+    required this.onTap,
+    required this.onShare,
+    required this.onReaction,
+    super.key,
+  });
+
+  final List<UserPost> posts;
+  final ValueChanged<UserPost> onTap;
+  final Future<void> Function(UserPost post) onShare;
+  final void Function(UserPost post, bool isLike) onReaction;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: posts.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 12),
+      itemBuilder: (context, index) {
+        final post = posts[index];
+        return _PostListTile(
+          post: post,
+          onTap: () => onTap(post),
+          onShare: () => onShare(post),
+          onReaction: (isLike) => onReaction(post, isLike),
+        );
+      },
+    );
+  }
+}
+
+class _PostListTile extends StatelessWidget {
+  const _PostListTile({
+    required this.post,
+    required this.onTap,
+    required this.onShare,
+    required this.onReaction,
+  });
+
+  final UserPost post;
+  final VoidCallback onTap;
+  final VoidCallback onShare;
+  final ValueChanged<bool> onReaction;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('yyyy.MM.dd HH:mm');
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      post.title,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.share_outlined),
+                    tooltip: '공유',
+                    onPressed: onShare,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  Chip(
+                    label: Text(post.nickname),
+                    avatar: const Icon(Icons.person_outline),
+                  ),
+                  Text(
+                    '작성 ${dateFormat.format(post.createdAt)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  Text(
+                    '수정 ${dateFormat.format(post.updatedAt)}',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              if (post.thumbnail.isNotEmpty)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: AspectRatio(
+                    aspectRatio: 16 / 9,
+                    child: Image.asset(
+                      post.thumbnail,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+              if (post.thumbnail.isNotEmpty) const SizedBox(height: 12),
+              Text(
+                post.plainSummary,
+                maxLines: 3,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              PostMetaRow(
+                post: post,
+                onReaction: onReaction,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/board/widgets/post_meta_row.dart
+++ b/lib/features/board/widgets/post_meta_row.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+
+import '../models/post_comment.dart';
+import '../models/user_post.dart';
+
+class PostMetaRow extends StatelessWidget {
+  const PostMetaRow({
+    required this.post,
+    required this.onReaction,
+    this.showCommentCount = true,
+    super.key,
+  });
+
+  final UserPost post;
+  final ValueChanged<bool> onReaction;
+  final bool showCommentCount;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Wrap(
+          spacing: 12,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          children: [
+            _MetaChip(
+              icon: Icons.visibility_outlined,
+              label: '${post.views}',
+              color: colorScheme.primary,
+            ),
+            _MetaChip(
+              icon: Icons.thumb_up_alt_outlined,
+              label: '${post.likes}',
+              color: colorScheme.tertiary,
+            ),
+            _MetaChip(
+              icon: Icons.thumb_down_alt_outlined,
+              label: '${post.dislikes}',
+              color: colorScheme.error,
+            ),
+            if (showCommentCount)
+              _MetaChip(
+                icon: Icons.chat_bubble_outline,
+                label: '${_countComments(post)}',
+                color: colorScheme.secondary,
+              ),
+          ],
+        ),
+        Wrap(
+          spacing: 8,
+          children: [
+            FilledButton.tonalIcon(
+              onPressed: () => onReaction(true),
+              icon: const Icon(Icons.thumb_up_alt_outlined),
+              label: const Text('좋아요'),
+            ),
+            FilledButton.tonalIcon(
+              onPressed: () => onReaction(false),
+              icon: const Icon(Icons.thumb_down_alt_outlined),
+              label: const Text('싫어요'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  int _countComments(UserPost post) {
+    int count = 0;
+    void visit(List<PostComment> comments) {
+      for (final comment in comments) {
+        count++;
+        if (comment.children.isNotEmpty) {
+          visit(comment.children);
+        }
+      }
+    }
+
+    visit(post.comments);
+    return count;
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      avatar: Icon(icon, size: 18, color: color),
+      label: Text(label),
+      side: BorderSide(color: color.withOpacity(0.2)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+    );
+  }
+}

--- a/lib/util/editor/ckeditor_field.dart
+++ b/lib/util/editor/ckeditor_field.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import 'src/ckeditor_platform.dart';
+
+class CkEditorField extends StatefulWidget {
+  const CkEditorField({
+    required this.initialValue,
+    required this.onChanged,
+    this.height = 320,
+    super.key,
+  });
+
+  final String initialValue;
+  final ValueChanged<String> onChanged;
+  final double height;
+
+  @override
+  State<CkEditorField> createState() => _CkEditorFieldState();
+}
+
+class _CkEditorFieldState extends State<CkEditorField> {
+  late String _value = widget.initialValue;
+
+  @override
+  void didUpdateWidget(covariant CkEditorField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialValue != widget.initialValue) {
+      _value = widget.initialValue;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final platformWidget = CkEditorPlatform.instance.build(
+      initialValue: _value,
+      height: widget.height,
+      onChanged: (value) {
+        setState(() {
+          _value = value;
+        });
+        widget.onChanged(value);
+      },
+    );
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(12),
+      child: Material(
+        elevation: 1,
+        clipBehavior: Clip.antiAlias,
+        child: SizedBox(
+          height: widget.height,
+          child: platformWidget,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/editor/src/ckeditor_platform.dart
+++ b/lib/util/editor/src/ckeditor_platform.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/widgets.dart';
+
+import 'ckeditor_platform_stub.dart'
+    if (dart.library.html) 'ckeditor_platform_web.dart'
+    if (dart.library.io) 'ckeditor_platform_mobile.dart';
+
+abstract class CkEditorPlatform {
+  Widget build({
+    required String initialValue,
+    required ValueChanged<String> onChanged,
+    required double height,
+  });
+
+  static CkEditorPlatform get instance => getPlatform();
+}

--- a/lib/util/editor/src/ckeditor_platform_mobile.dart
+++ b/lib/util/editor/src/ckeditor_platform_mobile.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import 'ckeditor_platform.dart';
+
+CkEditorPlatform getPlatform() => _MobileCkEditorPlatform();
+
+class _MobileCkEditorPlatform implements CkEditorPlatform {
+  @override
+  Widget build({
+    required String initialValue,
+    required ValueChanged<String> onChanged,
+    required double height,
+  }) {
+    return _MobileCkEditorView(
+      initialValue: initialValue,
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _MobileCkEditorView extends StatefulWidget {
+  const _MobileCkEditorView({
+    required this.initialValue,
+    required this.onChanged,
+  });
+
+  final String initialValue;
+  final ValueChanged<String> onChanged;
+
+  @override
+  State<_MobileCkEditorView> createState() => _MobileCkEditorViewState();
+}
+
+class _MobileCkEditorViewState extends State<_MobileCkEditorView> {
+  late final WebViewController _controller = WebViewController()
+    ..setJavaScriptMode(JavaScriptMode.unrestricted)
+    ..addJavaScriptChannel('EditorBridge', onMessageReceived: (message) {
+      widget.onChanged(message.message);
+    })
+    ..loadHtmlString(_buildHtml(widget.initialValue));
+
+  @override
+  void didUpdateWidget(covariant _MobileCkEditorView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialValue != widget.initialValue) {
+      final escaped = jsonEncode(widget.initialValue);
+      _controller.runJavaScript('window.__setData($escaped);');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return WebViewWidget(controller: _controller);
+  }
+
+  String _buildHtml(String initialValue) {
+    final escaped = jsonEncode(initialValue);
+    return '''
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; }
+      #editor { min-height: 100%; }
+    </style>
+    <script src="https://cdn.ckeditor.com/ckeditor5/41.4.2/classic/ckeditor.js"></script>
+  </head>
+  <body>
+    <div id="editor"></div>
+    <script>
+      const initialData = JSON.parse($escaped);
+      let editorRef = null;
+      ClassicEditor.create(document.querySelector('#editor'), {
+        toolbar: {
+          shouldNotGroupWhenFull: true
+        }
+      }).then(editor => {
+        editorRef = editor;
+        if (initialData) {
+          editor.setData(initialData);
+        }
+        editor.model.document.on('change:data', () => {
+          EditorBridge.postMessage(editor.getData());
+        });
+      });
+      window.__setData = (value) => {
+        if (editorRef) {
+          editorRef.setData(value || '');
+        }
+      };
+    </script>
+  </body>
+</html>
+''';
+  }
+}

--- a/lib/util/editor/src/ckeditor_platform_stub.dart
+++ b/lib/util/editor/src/ckeditor_platform_stub.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+import 'ckeditor_platform.dart';
+
+CkEditorPlatform getPlatform() => _StubCkEditorPlatform();
+
+class _StubCkEditorPlatform implements CkEditorPlatform {
+  @override
+  Widget build({
+    required String initialValue,
+    required ValueChanged<String> onChanged,
+    required double height,
+  }) {
+    return TextFormField(
+      initialValue: initialValue,
+      maxLines: null,
+      expands: true,
+      onChanged: onChanged,
+      decoration: const InputDecoration(
+        filled: true,
+        hintText: '콘텐츠를 입력하세요 (CKEditor 로딩 대기 중)',
+        border: InputBorder.none,
+        contentPadding: EdgeInsets.all(16),
+      ),
+    );
+  }
+}

--- a/lib/util/editor/src/ckeditor_platform_web.dart
+++ b/lib/util/editor/src/ckeditor_platform_web.dart
@@ -1,0 +1,142 @@
+// ignore_for_file: avoid_web_libraries_in_flutter
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import 'ckeditor_platform.dart';
+
+CkEditorPlatform getPlatform() => _WebCkEditorPlatform();
+
+class _WebCkEditorPlatform implements CkEditorPlatform {
+  @override
+  Widget build({
+    required String initialValue,
+    required ValueChanged<String> onChanged,
+    required double height,
+  }) {
+    return _CkEditorWebView(
+      initialValue: initialValue,
+      onChanged: onChanged,
+      height: height,
+    );
+  }
+}
+
+class _CkEditorWebView extends StatefulWidget {
+  const _CkEditorWebView({
+    required this.initialValue,
+    required this.onChanged,
+    required this.height,
+  });
+
+  final String initialValue;
+  final ValueChanged<String> onChanged;
+  final double height;
+
+  @override
+  State<_CkEditorWebView> createState() => _CkEditorWebViewState();
+}
+
+class _CkEditorWebViewState extends State<_CkEditorWebView> {
+  late final String _viewType =
+      'ckeditor-view-${DateTime.now().microsecondsSinceEpoch}';
+  html.IFrameElement? _iframeElement;
+  StreamSubscription<html.MessageEvent>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    ui.platformViewRegistry.registerViewFactory(_viewType, (int viewId) {
+      final iframe = html.IFrameElement()
+        ..style.border = '0'
+        ..style.width = '100%'
+        ..style.height = '100%'
+        ..srcdoc = _buildHtml(widget.initialValue);
+      _iframeElement = iframe;
+      _subscription = html.window.onMessage.listen(_handleMessage);
+      return iframe;
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant _CkEditorWebView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialValue != widget.initialValue) {
+      _postMessage({'type': 'set-data', 'payload': widget.initialValue});
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HtmlElementView(viewType: _viewType);
+  }
+
+  void _handleMessage(html.MessageEvent event) {
+    final data = event.data;
+    if (data is Map && data['type'] == 'ckeditor-change') {
+      widget.onChanged((data['payload'] as String?) ?? '');
+    }
+  }
+
+  void _postMessage(Object message) {
+    _iframeElement?.contentWindow?.postMessage(message, '*');
+  }
+
+  String _buildHtml(String initialValue) {
+    final escaped = jsonEncode(initialValue);
+    return '''
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      html, body { height: 100%; margin: 0; }
+      body { font-family: system-ui, sans-serif; background: transparent; }
+      #editor { min-height: 100%; }
+    </style>
+    <script src="https://cdn.ckeditor.com/ckeditor5/41.4.2/classic/ckeditor.js"></script>
+  </head>
+  <body>
+    <div id="editor"></div>
+    <script>
+      const initialData = JSON.parse($escaped);
+      let editorRef = null;
+      ClassicEditor.create(document.querySelector('#editor'), {
+        toolbar: {
+          shouldNotGroupWhenFull: true
+        }
+      }).then(editor => {
+        editorRef = editor;
+        if (initialData) {
+          editor.setData(initialData);
+        }
+        editor.model.document.on('change:data', () => {
+          window.parent.postMessage({ type: 'ckeditor-change', payload: editor.getData() }, '*');
+        });
+      });
+      window.addEventListener('message', (event) => {
+        if (!editorRef) {
+          return;
+        }
+        const data = event.data || {};
+        if (data.type === 'set-data') {
+          editorRef.setData(data.payload || '');
+        }
+      });
+    </script>
+  </body>
+</html>
+''';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,9 @@ dependencies:
   go_router: ^14.3.0
   provider: ^6.1.2
   encrypt: ^5.0.3
+  intl: ^0.19.0
+  flutter_html: ^3.0.0-beta.2
+  webview_flutter: ^4.7.0
 
 dev_dependencies:
   flutter_test:
@@ -61,6 +64,7 @@ flutter:
   uses-material-design: true
   assets:
     - assets/pics/
+    - assets/data/
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Summary
- add a fully featured board module with list/gallery layouts, CKEditor authoring, reactions, and nested comments backed by dummy JSON data
- wire the board into navigation, provide CKEditor platform integrations for web and mobile, and surface share/view counters on detail pages
- refresh documentation and schema notes to describe the new content model and sample data

## Testing
- flutter pub get *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d339f2a0888322a725c626df77172a