### PR TITLE
Fix BoardRepository default bundle initialization

### DIFF
--- a/lib/features/board/data/board_repository.dart
+++ b/lib/features/board/data/board_repository.dart
@@ -5,10 +5,10 @@ import 'package:flutter/services.dart';
 import '../models/board_post.dart';
 
 class BoardRepository {
-  const BoardRepository({
+  BoardRepository({
     this.assetPath = 'assets/data/free_board.json',
-    this.bundle = rootBundle,
-  });
+    AssetBundle? bundle,
+  }) : bundle = bundle ?? rootBundle;
 
   final String assetPath;
   final AssetBundle bundle;

--- a/lib/features/board/view/board_page.dart
+++ b/lib/features/board/view/board_page.dart
@@ -16,7 +16,7 @@ class BoardPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<BoardController>(
-      create: (_) => BoardController(repository: const BoardRepository())
+      create: (_) => BoardController(repository: BoardRepository())
         ..loadInitialPosts(),
       child: const _BoardView(),
     );


### PR DESCRIPTION
## Summary
- update BoardRepository to lazily default to rootBundle instead of using a const constructor
- adjust BoardPage to use the updated repository constructor

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d35e3fa22c8322aa0293a6c99fa012