### PR TITLE
Implement board permissions, author metadata, and asset embedding

### DIFF
--- a/lib/features/auth/data/dummy_user_repository.dart
+++ b/lib/features/auth/data/dummy_user_repository.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 import '../models/login_type.dart';
 import '../models/user.dart';
+import '../models/user_grade.dart';
 import '../models/user_wallet.dart';
 import '../services/crypto_service.dart';
 
@@ -28,25 +29,22 @@ class DummyUserRepository {
         _UserBundle(
           user: User(
             id: 'USR-2024001',
-            name: '청록 회원',
-            email: 'member@cheongnok.kr',
+            name: '김청록',
+            email: 'cheongrok@cheongnok.kr',
             encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
             loginType: LoginType.local,
-            nickname: '푸른바람',
-            points: 1250,
-            joinedAt: DateTime(now.year - 1, 5, 20, 10, 24),
-            updatedAt: DateTime(now.year, 2, 12, 9, 15),
-            nicknameUpdatedAt: DateTime(now.year, 1, 5, 20, 40),
-            authoredPostTitles: const [
-              '웹3 지갑 연동 가이드',
-              '자유게시판 규칙 정리',
-              '이번 주 실험실 소식',
-            ],
+            nickname: '청록고래',
+            grade: UserGrade.admin2,
+            points: 1820,
+            joinedAt: DateTime(now.year - 2, 4, 8, 9, 30),
+            updatedAt: DateTime(now.year, 1, 12, 11, 5),
+            nicknameUpdatedAt: DateTime(now.year - 1, 11, 20, 15, 45),
+            authoredPostTitles: const ['웹3 커뮤니티 온보딩 꿀팁', '온체인 거버넌스 워크숍'],
           ),
           wallet: UserWallet(
             userId: 'USR-2024001',
             metamaskAddress: '0x1fB2a489E1d7c2F4e3A1B8C9d0E2F3a4B5C6d7E8',
-            createdAt: DateTime(now.year - 1, 7, 2, 14, 12),
+            createdAt: DateTime(now.year - 2, 6, 14, 12, 0),
             lastSyncedAt: now.subtract(const Duration(hours: 12)),
             isActive: true,
           ),
@@ -56,24 +54,22 @@ class DummyUserRepository {
         _UserBundle(
           user: User(
             id: 'USR-2024002',
-            name: '카카오 손님',
-            email: 'kakao-user@cheongnok.kr',
+            name: '이메타',
+            email: 'meta@cheongnok.kr',
             encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForKakao'),
             loginType: LoginType.kakao,
-            nickname: '노란행성',
-            points: 480,
-            joinedAt: DateTime(now.year - 2, 3, 10, 8, 0),
+            nickname: '메타연구원',
+            grade: UserGrade.expert,
+            points: 1260,
+            joinedAt: DateTime(now.year - 3, 3, 10, 8, 0),
             updatedAt: DateTime(now.year - 1, 12, 25, 16, 35),
             nicknameUpdatedAt: DateTime(now.year - 1, 11, 2, 18, 10),
-            authoredPostTitles: const [
-              '카카오 로그인 연동 후기',
-              '포인트로 굿즈 사는 법',
-            ],
+            authoredPostTitles: const ['DAO 투표 시스템 실험 후기', '거버넌스 참여율 데이터 노트'],
           ),
           wallet: UserWallet(
             userId: 'USR-2024002',
             metamaskAddress: '0x9aE4b5C6d7E8F9a0B1C2d3E4F5a6B7c8D9E0F1A2',
-            createdAt: DateTime(now.year - 2, 8, 17, 11, 5),
+            createdAt: DateTime(now.year - 3, 8, 17, 11, 5),
             lastSyncedAt: now.subtract(const Duration(days: 3, hours: 4)),
             isActive: true,
           ),
@@ -83,27 +79,449 @@ class DummyUserRepository {
         _UserBundle(
           user: User(
             id: 'USR-2024003',
-            name: '네이버 손님',
-            email: 'naver-user@cheongnok.kr',
+            name: '박인터',
+            email: 'ui@cheongnok.kr',
             encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForNaver'),
             loginType: LoginType.naver,
-            nickname: '초록이슬',
-            points: 960,
-            joinedAt: DateTime(now.year - 3, 9, 30, 19, 50),
+            nickname: 'UI코더',
+            grade: UserGrade.semiExpert,
+            points: 980,
+            joinedAt: DateTime(now.year - 2, 9, 30, 19, 50),
             updatedAt: DateTime(now.year - 1, 6, 1, 9, 42),
             nicknameUpdatedAt: DateTime(now.year - 1, 5, 9, 7, 13),
-            authoredPostTitles: const [
-              '네이버 로그인 Q&A',
-              '정보 게시판 필독 공지',
-              '내가쓴글보기 기능 제안',
-            ],
+            authoredPostTitles: const ['커뮤니티 디자인 시스템 업데이트', '디자인 QA 체크리스트'],
           ),
           wallet: UserWallet(
             userId: 'USR-2024003',
             metamaskAddress: '0x7bC8d9E0F1A2b3C4d5E6f7A8B9c0D1E2F3A4B5C6',
-            createdAt: DateTime(now.year - 3, 10, 1, 8, 45),
+            createdAt: DateTime(now.year - 2, 10, 1, 8, 45),
             lastSyncedAt: now.subtract(const Duration(days: 10)),
             isActive: false,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024004',
+            name: '장다리',
+            email: 'bridge@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '브릿지메이커',
+            grade: UserGrade.regular,
+            points: 720,
+            joinedAt: DateTime(now.year - 1, 2, 12, 9, 15),
+            updatedAt: DateTime(now.year, 2, 22, 14, 10),
+            nicknameUpdatedAt: DateTime(now.year - 1, 12, 1, 17, 20),
+            authoredPostTitles: const ['생태계 파트너십 제안서', '협업 파트너 체크리스트'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024004',
+            metamaskAddress: '0x5cD7e8F9012a3b4C5d6E7f8A9B0c1D2E3f4A5B6',
+            createdAt: DateTime(now.year - 1, 3, 5, 10, 20),
+            lastSyncedAt: now.subtract(const Duration(days: 5, hours: 6)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024005',
+            name: '문소식',
+            email: 'newsletter@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '뉴스레터장인',
+            grade: UserGrade.semiExpert,
+            points: 1540,
+            joinedAt: DateTime(now.year - 2, 7, 18, 13, 5),
+            updatedAt: DateTime(now.year - 1, 9, 14, 10, 0),
+            nicknameUpdatedAt: DateTime(now.year - 1, 9, 1, 8, 45),
+            authoredPostTitles: const ['제휴 뉴스레터 배포 결과', '콘텐츠 캘린더 초안'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024005',
+            metamaskAddress: '0x4bA6c7D8e9F0123A4b5C6d7E8F9a0B1C2d3E4f5',
+            createdAt: DateTime(now.year - 2, 8, 20, 9, 30),
+            lastSyncedAt: now.subtract(const Duration(days: 2, hours: 8)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024006',
+            name: '정가드',
+            email: 'guardian@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '커뮤니티가드',
+            grade: UserGrade.admin1,
+            points: 2100,
+            joinedAt: DateTime(now.year - 3, 5, 14, 7, 40),
+            updatedAt: DateTime(now.year, 3, 2, 9, 5),
+            nicknameUpdatedAt: DateTime(now.year - 1, 8, 19, 20, 15),
+            authoredPostTitles: const ['커뮤니티 가이드라인 개정', '신규 멤버 온보딩 체크'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024006',
+            metamaskAddress: '0x3a95b6C7d8E9f0A1B2c3D4e5F6a7B8c9D0e1F2a',
+            createdAt: DateTime(now.year - 3, 6, 11, 18, 25),
+            lastSyncedAt: now.subtract(const Duration(hours: 3, minutes: 30)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024007',
+            name: '최멘토',
+            email: 'mentor@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForKakao'),
+            loginType: LoginType.kakao,
+            nickname: '멘토링리드',
+            grade: UserGrade.expert,
+            points: 990,
+            joinedAt: DateTime(now.year - 1, 4, 3, 11, 25),
+            updatedAt: DateTime(now.year, 1, 28, 15, 0),
+            nicknameUpdatedAt: DateTime(now.year - 1, 10, 12, 9, 0),
+            authoredPostTitles: const ['커뮤니티 멘토링 프로그램', '멘토 피드백 수집법'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024007',
+            metamaskAddress: '0x2b84c5D6e7F8091A2b3C4d5E6F7a8B9c0D1E2f3',
+            createdAt: DateTime(now.year - 1, 5, 8, 13, 40),
+            lastSyncedAt: now.subtract(const Duration(days: 7)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024008',
+            name: '권토큰',
+            email: 'token@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '토큰디자이너',
+            grade: UserGrade.developer,
+            points: 1750,
+            joinedAt: DateTime(now.year - 2, 11, 22, 14, 55),
+            updatedAt: DateTime(now.year - 1, 10, 2, 19, 30),
+            nicknameUpdatedAt: DateTime(now.year - 1, 7, 21, 16, 5),
+            authoredPostTitles: const ['탈중앙 보상 시스템 설계', '보상 토큰 시뮬레이션'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024008',
+            metamaskAddress: '0x8cD1e2F3a4B5c6D7e8F9012A3b4C5d6E7f8A9b0',
+            createdAt: DateTime(now.year - 2, 12, 2, 10, 10),
+            lastSyncedAt: now.subtract(const Duration(hours: 18)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024009',
+            name: '신운영',
+            email: 'operation@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '운영리더',
+            grade: UserGrade.admin2,
+            points: 2380,
+            joinedAt: DateTime(now.year - 4, 1, 15, 9, 0),
+            updatedAt: DateTime(now.year, 2, 5, 8, 20),
+            nicknameUpdatedAt: DateTime(now.year - 1, 3, 28, 17, 45),
+            authoredPostTitles: const ['월간 운영 보고서', '운영 현황 점검 회의록'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024009',
+            metamaskAddress: '0x6dE0f1A2b3C4d5E6f7A8b9C0D1e2F3A4b5C6d7E',
+            createdAt: DateTime(now.year - 4, 2, 1, 14, 30),
+            lastSyncedAt: now.subtract(const Duration(hours: 1, minutes: 45)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024010',
+            name: '서가이드',
+            email: 'sherpa@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForNaver'),
+            loginType: LoginType.naver,
+            nickname: '콘텐츠셰르파',
+            grade: UserGrade.regular,
+            points: 880,
+            joinedAt: DateTime(now.year - 2, 5, 6, 16, 10),
+            updatedAt: DateTime(now.year - 1, 4, 14, 9, 50),
+            nicknameUpdatedAt: DateTime(now.year - 1, 2, 20, 7, 35),
+            authoredPostTitles: const ['콘텐츠 큐레이션 방법', '추천 아티클 아카이브'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024010',
+            metamaskAddress: '0x9eF0123A4b5C6d7E8f9A0B1c2D3e4F5A6b7C8d9',
+            createdAt: DateTime(now.year - 2, 6, 1, 9, 25),
+            lastSyncedAt: now.subtract(const Duration(days: 14)),
+            isActive: false,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024011',
+            name: '안커넥',
+            email: 'connector@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '커넥터',
+            grade: UserGrade.semiExpert,
+            points: 1330,
+            joinedAt: DateTime(now.year - 2, 1, 9, 10, 45),
+            updatedAt: DateTime(now.year - 1, 8, 30, 11, 25),
+            nicknameUpdatedAt: DateTime(now.year - 1, 5, 18, 9, 15),
+            authoredPostTitles: const ['네트워킹 데이 리캡', '파트너십 문의 로그'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024011',
+            metamaskAddress: '0x1a23b45C6d7E8f9A0b1C2d3E4f5A6b7C8d9E0f1',
+            createdAt: DateTime(now.year - 2, 2, 4, 15, 10),
+            lastSyncedAt: now.subtract(const Duration(days: 1, hours: 6)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024012',
+            name: '백데이터',
+            email: 'data@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '데이터관리자',
+            grade: UserGrade.expert,
+            points: 1680,
+            joinedAt: DateTime(now.year - 3, 10, 12, 9, 5),
+            updatedAt: DateTime(now.year - 1, 11, 22, 12, 40),
+            nicknameUpdatedAt: DateTime(now.year - 1, 7, 8, 18, 0),
+            authoredPostTitles: const ['데이터 품질 점검 보고', '대시보드 사용 가이드'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024012',
+            metamaskAddress: '0x2c34d56E7f8A9b0C1d2E3f4A5b6C7d8E9f0A1b2',
+            createdAt: DateTime(now.year - 3, 11, 1, 11, 55),
+            lastSyncedAt: now.subtract(const Duration(hours: 5, minutes: 20)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024013',
+            name: '류릴리즈',
+            email: 'release@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForKakao'),
+            loginType: LoginType.kakao,
+            nickname: '릴리즈매니저',
+            grade: UserGrade.admin1,
+            points: 1900,
+            joinedAt: DateTime(now.year - 2, 3, 22, 14, 30),
+            updatedAt: DateTime(now.year, 1, 14, 10, 20),
+            nicknameUpdatedAt: DateTime(now.year - 1, 9, 6, 8, 10),
+            authoredPostTitles: const ['릴리즈 체크리스트', '릴리즈 회고 노트'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024013',
+            metamaskAddress: '0x3d45e67F8a9B0c1D2e3F4a5B6c7D8e9F0a1B2c3',
+            createdAt: DateTime(now.year - 2, 4, 2, 9, 15),
+            lastSyncedAt: now.subtract(const Duration(hours: 2)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024014',
+            name: '한마켓',
+            email: 'market@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '마켓플래너',
+            grade: UserGrade.regular,
+            points: 860,
+            joinedAt: DateTime(now.year - 1, 6, 15, 10, 5),
+            updatedAt: DateTime(now.year, 2, 10, 16, 35),
+            nicknameUpdatedAt: DateTime(now.year - 1, 12, 20, 11, 0),
+            authoredPostTitles: const ['캠페인 A/B 테스트', '시장 조사 인사이트'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024014',
+            metamaskAddress: '0x4e56f7801A2b3C4d5E6f7A8B9c0D1e2F3a4B5c6',
+            createdAt: DateTime(now.year - 1, 7, 1, 13, 30),
+            lastSyncedAt: now.subtract(const Duration(days: 9)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024015',
+            name: '표무대',
+            email: 'stage@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForNaver'),
+            loginType: LoginType.naver,
+            nickname: '스테이지디렉터',
+            grade: UserGrade.admin2,
+            points: 2050,
+            joinedAt: DateTime(now.year - 3, 1, 18, 15, 20),
+            updatedAt: DateTime(now.year - 1, 5, 30, 10, 45),
+            nicknameUpdatedAt: DateTime(now.year - 1, 4, 4, 14, 55),
+            authoredPostTitles: const ['행사 운영 매뉴얼', '프로덕션 체크리스트'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024015',
+            metamaskAddress: '0x5f67012A3b4C5d6E7f8A9b0C1d2E3f4A5b6C7d8',
+            createdAt: DateTime(now.year - 3, 2, 9, 17, 0),
+            lastSyncedAt: now.subtract(const Duration(days: 4, hours: 6)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024016',
+            name: '노자동',
+            email: 'auto@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '오토메이터',
+            grade: UserGrade.developer,
+            points: 1720,
+            joinedAt: DateTime(now.year - 2, 8, 4, 9, 55),
+            updatedAt: DateTime(now.year - 1, 10, 14, 12, 25),
+            nicknameUpdatedAt: DateTime(now.year - 1, 7, 2, 10, 5),
+            authoredPostTitles: const ['자동화 스크립트 모음', '워크플로 모니터링'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024016',
+            metamaskAddress: '0x6a78123A4b5C6d7E8f9A0b1C2d3E4f5A6b7C8d9',
+            createdAt: DateTime(now.year - 2, 9, 12, 16, 40),
+            lastSyncedAt: now.subtract(const Duration(hours: 7, minutes: 10)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024017',
+            name: '송디아이',
+            email: 'did@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForKakao'),
+            loginType: LoginType.kakao,
+            nickname: 'DID탐험가',
+            grade: UserGrade.semiExpert,
+            points: 940,
+            joinedAt: DateTime(now.year - 1, 9, 23, 8, 35),
+            updatedAt: DateTime(now.year, 1, 5, 11, 50),
+            nicknameUpdatedAt: DateTime(now.year - 1, 12, 18, 14, 15),
+            authoredPostTitles: const ['DID 서비스 실험기', '분산 신원 도입 제안'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024017',
+            metamaskAddress: '0x7b89234A5b6C7d8E9f0A1b2C3d4E5f6A7b8C9d0',
+            createdAt: DateTime(now.year - 1, 10, 10, 9, 30),
+            lastSyncedAt: now.subtract(const Duration(days: 6)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024018',
+            name: '임시스',
+            email: 'system@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '시스템설계자',
+            grade: UserGrade.expert,
+            points: 1620,
+            joinedAt: DateTime(now.year - 3, 4, 27, 13, 15),
+            updatedAt: DateTime(now.year - 1, 9, 9, 18, 5),
+            nicknameUpdatedAt: DateTime(now.year - 1, 6, 30, 9, 40),
+            authoredPostTitles: const ['신규 멤버 온체인 인증 흐름', '시스템 구조 리팩토링'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024018',
+            metamaskAddress: '0x8c9a345B6c7D8e9F0a1B2c3D4e5F6a7B8c9D0e1',
+            createdAt: DateTime(now.year - 3, 5, 6, 15, 50),
+            lastSyncedAt: now.subtract(const Duration(hours: 9)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024019',
+            name: '주체크',
+            email: 'checkpoint@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('EncryptedTokenForNaver'),
+            loginType: LoginType.naver,
+            nickname: '체크포인트',
+            grade: UserGrade.regular,
+            points: 810,
+            joinedAt: DateTime(now.year - 1, 3, 14, 10, 20),
+            updatedAt: DateTime(now.year - 1, 12, 28, 15, 5),
+            nicknameUpdatedAt: DateTime(now.year - 1, 11, 10, 13, 15),
+            authoredPostTitles: const ['QA 체크포인트 공유', '업데이트 체커'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024019',
+            metamaskAddress: '0x9dab456C7d8E9f0A1b2C3d4E5f6A7b8C9d0E1f2',
+            createdAt: DateTime(now.year - 1, 4, 5, 12, 30),
+            lastSyncedAt: now.subtract(const Duration(days: 3)),
+            isActive: true,
+          ),
+        ),
+      )
+      ..add(
+        _UserBundle(
+          user: User(
+            id: 'USR-2024020',
+            name: '배언어',
+            email: 'language@cheongnok.kr',
+            encryptedPassword: _cryptoService.encryptSensitive('S@feLocalPass!1'),
+            loginType: LoginType.local,
+            nickname: '언어마스터',
+            grade: UserGrade.expert,
+            points: 1470,
+            joinedAt: DateTime(now.year - 2, 4, 1, 8, 10),
+            updatedAt: DateTime(now.year - 1, 5, 25, 19, 35),
+            nicknameUpdatedAt: DateTime(now.year - 1, 5, 10, 14, 45),
+            authoredPostTitles: const ['다국어 번역 가이드', '용어집 관리 전략'],
+          ),
+          wallet: UserWallet(
+            userId: 'USR-2024020',
+            metamaskAddress: '0xaebc567D8e9F0a1B2c3D4e5F6a7B8c9D0e1F2a3',
+            createdAt: DateTime(now.year - 2, 4, 20, 10, 5),
+            lastSyncedAt: now.subtract(const Duration(hours: 12, minutes: 20)),
+            isActive: true,
           ),
         ),
       );

--- a/lib/features/auth/models/user.dart
+++ b/lib/features/auth/models/user.dart
@@ -2,6 +2,7 @@
 // 파일 설명: 로그인한 회원 프로필을 표현하는 불변 도메인 모델.
 
 import 'login_type.dart';
+import 'user_grade.dart';
 
 /// 인증·감사·콘텐츠 개인화에 필요한 메타데이터를 담은 플랫폼 회원 모델.
 class User {
@@ -13,6 +14,7 @@ class User {
     required this.encryptedPassword,
     required this.loginType,
     required this.nickname,
+    required this.grade,
     required this.points,
     required this.joinedAt,
     required this.updatedAt,
@@ -40,6 +42,9 @@ class User {
 
   /// 게시글에 표시되는 닉네임.
   final String nickname;
+
+  /// 회원 권한을 나타내는 등급.
+  final UserGrade grade;
 
   /// 회원의 현재 포인트 잔액.
   final int points;
@@ -83,6 +88,7 @@ class User {
     String? encryptedPassword,
     LoginType? loginType,
     String? nickname,
+    UserGrade? grade,
     int? points,
     DateTime? joinedAt,
     DateTime? updatedAt,
@@ -96,6 +102,7 @@ class User {
       encryptedPassword: encryptedPassword ?? this.encryptedPassword,
       loginType: loginType ?? this.loginType,
       nickname: nickname ?? this.nickname,
+      grade: grade ?? this.grade,
       points: points ?? this.points,
       joinedAt: joinedAt ?? this.joinedAt,
       updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/features/auth/models/user_grade.dart
+++ b/lib/features/auth/models/user_grade.dart
@@ -1,0 +1,30 @@
+/// 회원 등급을 정의한 열거형.
+enum UserGrade {
+  all('모두', 0),
+  regular('일반', 1),
+  semiExpert('준문가', 2),
+  expert('전문가', 3),
+  admin1('관리자1', 4),
+  admin2('관리자2', 5),
+  developer('개발자', 6),
+  master('마스터', 7);
+
+  const UserGrade(this.label, this.rank);
+
+  /// 화면에 노출할 한글 등급명.
+  final String label;
+
+  /// 권한 비교에 사용할 정수 랭크. 값이 클수록 높은 등급이다.
+  final int rank;
+
+  /// 운영자(관리자1) 이상 등급인지 여부.
+  bool get isOperator => rank >= UserGrade.admin1.rank;
+
+  /// 등급명을 통해 [UserGrade]를 조회한다.
+  static UserGrade fromLabel(String label) {
+    return UserGrade.values.firstWhere(
+      (grade) => grade.label == label,
+      orElse: () => UserGrade.regular,
+    );
+  }
+}

--- a/lib/features/board/data/board_repository.dart
+++ b/lib/features/board/data/board_repository.dart
@@ -5,10 +5,10 @@ import 'package:flutter/services.dart';
 import '../models/board_post.dart';
 
 class BoardRepository {
-  const BoardRepository({
+  BoardRepository({
     this.assetPath = 'assets/data/free_board.json',
-    this.bundle = rootBundle,
-  });
+    AssetBundle? bundle,
+  }) : bundle = bundle ?? rootBundle;
 
   final String assetPath;
   final AssetBundle bundle;
@@ -19,7 +19,29 @@ class BoardRepository {
     final posts = jsonMap['posts'] as List<dynamic>? ?? <dynamic>[];
     return [
       for (final post in posts)
-        BoardPost.fromJson(post as Map<String, dynamic>),
+        _embedImages(BoardPost.fromJson(post as Map<String, dynamic>)),
     ];
+  }
+
+  BoardPost _embedImages(BoardPost post) {
+    if (post.images.isEmpty) {
+      return post;
+    }
+    final content = post.content;
+    final buffer = StringBuffer(content.trim());
+    var modified = false;
+    for (final image in post.images) {
+      if (!content.contains(image)) {
+        if (buffer.isNotEmpty) {
+          buffer.write('\n');
+        }
+        buffer.write('<figure class="image"><img src="$image" alt="첨부 이미지" /></figure>');
+        modified = true;
+      }
+    }
+    if (!modified) {
+      return post;
+    }
+    return post.copyWith(content: buffer.toString());
   }
 }

--- a/lib/features/board/view/board_page.dart
+++ b/lib/features/board/view/board_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
+import 'package:untitled3/features/auth/controllers/auth_controller.dart';
+import 'package:untitled3/features/auth/models/user_grade.dart';
+
 import '../controllers/board_controller.dart';
 import '../data/board_repository.dart';
 import '../models/board_post.dart';
@@ -16,7 +19,7 @@ class BoardPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<BoardController>(
-      create: (_) => BoardController(repository: const BoardRepository())
+      create: (_) => BoardController(repository: BoardRepository())
         ..loadInitialPosts(),
       child: const _BoardView(),
     );
@@ -30,6 +33,15 @@ class _BoardView extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final controller = context.watch<BoardController>();
+    final auth = context.watch<AuthController>();
+    final canChangeViewMode = auth.currentUser?.grade.isOperator ?? false;
+    if (!canChangeViewMode && controller.viewMode != BoardViewMode.list) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (controller.viewMode != BoardViewMode.list) {
+          controller.setViewMode(BoardViewMode.list);
+        }
+      });
+    }
     return Stack(
       children: [
         Padding(
@@ -37,7 +49,11 @@ class _BoardView extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              _BoardToolbar(controller: controller),
+              _BoardToolbar(
+                controller: controller,
+                canChangeViewMode: canChangeViewMode,
+                userGrade: auth.currentUser?.grade,
+              ),
               const SizedBox(height: 16),
               Expanded(
                 child: controller.isLoading
@@ -76,12 +92,20 @@ class _BoardView extends StatelessWidget {
 }
 
 class _BoardToolbar extends StatelessWidget {
-  const _BoardToolbar({required this.controller});
+  const _BoardToolbar({
+    required this.controller,
+    required this.canChangeViewMode,
+    this.userGrade,
+  });
 
   final BoardController controller;
+  final bool canChangeViewMode;
+  final UserGrade? userGrade;
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final gradeLabel = userGrade?.label ?? UserGrade.all.label;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -96,28 +120,43 @@ class _BoardToolbar extends StatelessWidget {
           crossAxisAlignment: WrapCrossAlignment.center,
           children: [
             SegmentedButton<BoardViewMode>(
-              segments: const [
-                ButtonSegment<BoardViewMode>(
+              segments: [
+                const ButtonSegment<BoardViewMode>(
                   value: BoardViewMode.list,
                   icon: Icon(Icons.view_list_outlined),
                   label: Text('리스트'),
                 ),
                 ButtonSegment<BoardViewMode>(
                   value: BoardViewMode.gallery,
-                  icon: Icon(Icons.grid_view_rounded),
-                  label: Text('갤러리'),
+                  icon: const Icon(Icons.grid_view_rounded),
+                  label: const Text('갤러리'),
+                  enabled: canChangeViewMode,
                 ),
               ],
               selected: <BoardViewMode>{controller.viewMode},
-              onSelectionChanged: (selection) {
-                controller.setViewMode(selection.first);
-              },
+              onSelectionChanged: canChangeViewMode
+                  ? (selection) {
+                      controller.setViewMode(selection.first);
+                    }
+                  : null,
             ),
             const SizedBox(width: 12),
             Text(
               '총 ${controller.posts.length}건',
               style: Theme.of(context).textTheme.bodyMedium,
             ),
+            Chip(
+              label: Text('등급: $gradeLabel'),
+              visualDensity: VisualDensity.compact,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+            ),
+            if (!canChangeViewMode)
+              Text(
+                '운영자 등급 이상만 보기 전환이 가능합니다.',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.error,
+                ),
+              ),
           ],
         ),
       ],

--- a/lib/features/board/view/widgets/post_list_tile.dart
+++ b/lib/features/board/view/widgets/post_list_tile.dart
@@ -23,101 +23,65 @@ class PostListTile extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
-        child: SizedBox(
-          height: 150,
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
             children: [
-              AspectRatio(
-                aspectRatio: 4 / 3,
-                child: _PostImage(path: post.coverImage),
-              ),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        post.title,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Expanded(
-                        child: Text(
-                          post.summary.isEmpty ? '상세 내용을 확인해보세요.' : post.summary,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
-                          ),
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 12,
-                        runSpacing: 8,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          _InfoChip(
-                            icon: Icons.person_outline,
-                            label: post.nickname,
-                          ),
-                          _InfoChip(
-                            icon: Icons.schedule_outlined,
-                            label: formattedDate,
-                          ),
-                          _InfoChip(
-                            icon: Icons.remove_red_eye_outlined,
-                            label: '${post.views}',
-                          ),
-                          _InfoChip(
-                            icon: Icons.thumb_up_outlined,
-                            label: '${post.likes}',
-                          ),
-                          _InfoChip(
-                            icon: Icons.thumb_down_outlined,
-                            label: '${post.dislikes}',
-                          ),
-                          _InfoChip(
-                            icon: Icons.chat_bubble_outline,
-                            label: '${countComments(post.comments)}',
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
+              Text(
+                post.title,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
                 ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                post.summary.isEmpty ? '상세 내용을 확인해보세요.' : post.summary,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.textTheme.bodyMedium?.color?.withOpacity(0.7),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 12,
+                runSpacing: 8,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  _InfoChip(
+                    icon: Icons.person_outline,
+                    label: post.nickname,
+                  ),
+                  _InfoChip(
+                    icon: Icons.schedule_outlined,
+                    label: formattedDate,
+                  ),
+                  _InfoChip(
+                    icon: Icons.remove_red_eye_outlined,
+                    label: '${post.views}',
+                  ),
+                  _InfoChip(
+                    icon: Icons.thumb_up_outlined,
+                    label: '${post.likes}',
+                  ),
+                  _InfoChip(
+                    icon: Icons.thumb_down_outlined,
+                    label: '${post.dislikes}',
+                  ),
+                  _InfoChip(
+                    icon: Icons.chat_bubble_outline,
+                    label: '${countComments(post.comments)}',
+                  ),
+                ],
               ),
             ],
           ),
         ),
       ),
-    );
-  }
-}
-
-class _PostImage extends StatelessWidget {
-  const _PostImage({required this.path});
-
-  final String path;
-
-  @override
-  Widget build(BuildContext context) {
-    return Image.asset(
-      path,
-      fit: BoxFit.cover,
-      errorBuilder: (context, error, stackTrace) {
-        return Container(
-          color: Theme.of(context).colorScheme.surfaceVariant,
-          alignment: Alignment.center,
-          child: const Icon(Icons.broken_image_outlined, size: 32),
-        );
-      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a user grade model and expand the dummy user roster so board authors reference graded profiles
- remove thumbnails from the list view, auto-fill post authors, and embed selected images into post content
- gate the gallery toggle behind operator-level grades while surfacing the viewer's grade on the board toolbar

## Testing
- dart format lib/features *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d35e3fa22c8322aa0293a6c99fa012