### PR TITLE
Enable CKEditor image resizing on web

### DIFF
--- a/lib/features/board/widgets/ckeditor5_platform_web.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_web.dart
@@ -135,6 +135,39 @@ String _buildEditorHtml(String initialHtml, String editorId) {
     ClassicEditor.create(document.querySelector('#editor'), {
       toolbar: {
         shouldNotGroupWhenFull: true
+      },
+      image: {
+        resizeUnit: '%',
+        resizeOptions: [
+          {
+            name: 'resizeImage:original',
+            label: 'Original',
+            value: null
+          },
+          {
+            name: 'resizeImage:25',
+            label: '25%',
+            value: '25'
+          },
+          {
+            name: 'resizeImage:50',
+            label: '50%',
+            value: '50'
+          },
+          {
+            name: 'resizeImage:75',
+            label: '75%',
+            value: '75'
+          }
+        ],
+        toolbar: [
+          'imageStyle:inline',
+          'imageStyle:block',
+          'imageStyle:side',
+          '|',
+          'resizeImage',
+          'imageTextAlternative'
+        ]
       }
     }).then(editor => {
       editorInstance = editor;


### PR DESCRIPTION
## Summary
- enable CKEditor image resizing by configuring resize toolbar options in the web platform view
- expose additional image style controls alongside resize actions

## Testing
- `flutter analyze` *(fails: flutter is not installed in the execution environment)*
- `dart analyze` *(fails: dart is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e9de60d88322bd2c9237eb2efaa8