### PR TITLE
Switch CKEditor integration to super build

### DIFF
--- a/lib/features/board/widgets/ckeditor5_platform_web.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_web.dart
@@ -104,7 +104,7 @@ String _buildEditorHtml(String initialHtml, String editorId) {
     body { margin: 0; padding: 0; background: transparent; }
     #editor { min-height: 280px; }
   </style>
-  <script src="https://cdn.ckeditor.com/ckeditor5/41.2.0/classic/ckeditor.js"></script>
+  <script src="https://cdn.ckeditor.com/ckeditor5/41.2.1/super-build/ckeditor.js"></script>
 </head>
 <body>
   <div id="editor"></div>
@@ -132,33 +132,101 @@ String _buildEditorHtml(String initialHtml, String editorId) {
       return null;
     };
 
-    ClassicEditor.create(document.querySelector('#editor'), {
-      toolbar: {
-        shouldNotGroupWhenFull: true
-      }
-    }).then(editor => {
-      editorInstance = editor;
-      editor.model.document.on('change:data', () => {
-        postMessage({ type: 'change', data: editor.getData() });
-      });
-      editor.setData(${escapedInitial} || '');
-      postMessage({ type: 'ready' });
-      window.addEventListener('message', event => {
-        let payload = event.data;
-        if (typeof payload === 'string') {
-          try {
-            payload = JSON.parse(payload);
-          } catch (error) {
-            payload = null;
+    const classicEditorConstructor = window.CKEDITOR && window.CKEDITOR.ClassicEditor;
+    if (!classicEditorConstructor) {
+      console.error('CKEditor super build is not available.');
+    } else {
+      classicEditorConstructor.create(document.querySelector('#editor'), {
+        toolbar: {
+          items: [
+            'heading',
+            '|',
+            'bold',
+            'italic',
+            'underline',
+            'strikethrough',
+            '|',
+            'bulletedList',
+            'numberedList',
+            '|',
+            'outdent',
+            'indent',
+            '|',
+            'link',
+            'blockQuote',
+            'insertTable',
+            'mediaEmbed',
+            '|',
+            'undo',
+            'redo'
+          ],
+          shouldNotGroupWhenFull: true
+        },
+        image: {
+          resizeUnit: '%',
+          resizeOptions: [
+            {
+              name: 'resizeImage:original',
+              label: 'Original',
+              value: null
+            },
+            {
+              name: 'resizeImage:25',
+              label: '25%',
+              value: '25'
+            },
+            {
+              name: 'resizeImage:50',
+              label: '50%',
+              value: '50'
+            },
+            {
+              name: 'resizeImage:75',
+              label: '75%',
+              value: '75'
+            }
+          ],
+          toolbar: [
+            'toggleImageCaption',
+            'imageTextAlternative',
+            '|',
+            'imageStyle:inline',
+            'imageStyle:block',
+            'imageStyle:side',
+            '|',
+            'resizeImage'
+          ]
+        },
+        removePlugins: [
+          'AIAssistant',
+          'CKBox',
+          'CKFinder',
+          'EasyImage'
+        ]
+      }).then(editor => {
+        editorInstance = editor;
+        editor.model.document.on('change:data', () => {
+          postMessage({ type: 'change', data: editor.getData() });
+        });
+        editor.setData(${escapedInitial} || '');
+        postMessage({ type: 'ready' });
+        window.addEventListener('message', event => {
+          let payload = event.data;
+          if (typeof payload === 'string') {
+            try {
+              payload = JSON.parse(payload);
+            } catch (error) {
+              payload = null;
+            }
           }
-        }
-        if (payload && payload.editorId === editorId) {
-          window.handleMessage(payload);
-        }
+          if (payload && payload.editorId === editorId) {
+            window.handleMessage(payload);
+          }
+        });
+      }).catch(error => {
+        console.error(error);
       });
-    }).catch(error => {
-      console.error(error);
-    });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the CKEditor 5 41.2.1 super build bundle instead of the classic build
- initialize the editor through the super build API with a toolbar, image resize options, and caption controls
- disable premium upload plugins so the super build works without extra configuration

## Testing
- `flutter analyze` *(fails: flutter is not installed in the execution environment)*
- `dart analyze` *(fails: dart is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e9de60d88322bd2c9237eb2efaa8