### PR TITLE
docs: refresh structure overview and add Korean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ lib/
 │   │   ├── models/
 │   │   │   ├── login_type.dart
 │   │   │   ├── user.dart
+│   │   │   ├── user_grade.dart
 │   │   │   └── user_wallet.dart
 │   │   ├── services/
 │   │   │   ├── crypto_service.dart
@@ -40,17 +41,21 @@ lib/
 │   │   ├── view/
 │   │   │   ├── board_page.dart
 │   │   │   ├── post_detail_page.dart
-│   │   │   └── post_editor_page.dart
+│   │   │   ├── post_editor_page.dart
+│   │   │   └── widgets/
+│   │   │       ├── post_gallery_tile.dart
+│   │   │       └── post_list_tile.dart
 │   │   └── widgets/
 │   │       ├── ckeditor5.dart
-│   │       ├── ckeditor5_platform_io.dart
 │   │       ├── ckeditor5_platform_interface.dart
+│   │       ├── ckeditor5_platform_io.dart
 │   │       ├── ckeditor5_platform_web.dart
-│   │       ├── comment_utils.dart
-│   │       ├── post_gallery_tile.dart
-│   │       └── post_list_tile.dart
+│   │       └── comment_utils.dart
 │   └── simple_page/
 │       └── simple_page.dart
+├── util/
+│   └── editor/
+│       ├── package.json 외 CKEditor 5 빌드 설정 파일 다수
 └── main.dart
 ```
 
@@ -62,9 +67,10 @@ lib/
   - `navigation/`: 내비게이션 관련 컨트롤러와 공용 위젯, 목적지 정의를 포함합니다.
   - `router/`: `GoRouter` 구성을 담당합니다.
 - **lib/features**: 실제 화면(Feature)을 모듈 단위로 관리합니다.
-  - `auth/`: 로그인, 사용자/지갑 더미 데이터, 암호화 서비스를 포함하는 인증 모듈입니다.
-  - `board/`: 자유 게시판 기능(리스트/갤러리 전환, CKEditor 5 기반 에디터, 댓글/대댓글, 좋아요·싫어요·공유)을 제공합니다.
+  - `auth/`: 로그인 UI(`view/login_page.dart`), AES-256 암호화(`services/crypto_service.dart`), 메타마스크 연동(`services/metamask_connector.dart`), 등급·회원 모델(`models/user_grade.dart`, `models/user.dart`)과 더미 데이터 저장소(`data/dummy_user_repository.dart`)를 포함합니다.
+  - `board/`: 자유 게시판 기능(리스트/갤러리 전환, CKEditor 5 기반 에디터, 댓글/대댓글, 좋아요·싫어요·공유)을 제공합니다. 뷰 전용 위젯(`view/widgets/`), 에디터 브리지(`widgets/ckeditor5*.dart`), 상태 관리(`controllers/board_controller.dart`)가 역할별로 분리되어 있습니다.
   - `simple_page/`: 개발 중인 메뉴를 대신 보여주는 플레이스홀더 화면입니다.
+- **lib/util/editor**: CKEditor 5 원본 소스와 pnpm 기반 빌드 설정을 보관합니다.
 
 ## 자유 게시판 데이터
 

--- a/lib/app/app_root.dart
+++ b/lib/app/app_root.dart
@@ -12,6 +12,7 @@ import 'package:untitled3/features/auth/services/metamask_connector.dart';
 import 'navigation/navigation_controller.dart';
 import 'router/app_router.dart';
 
+/// DI 컨테이너와 라우터를 초기화하는 애플리케이션 루트 위젯.
 class AppRoot extends StatefulWidget {
   const AppRoot({super.key});
 
@@ -19,9 +20,11 @@ class AppRoot extends StatefulWidget {
   State<AppRoot> createState() => _AppRootState();
 }
 
+/// 루트 위젯이 보유한 상태. 라우터를 초기화하고 Providers를 묶어준다.
 class _AppRootState extends State<AppRoot> {
   late final GoRouter _router = AppRouter().router;
 
+  /// 전역 의존성 주입과 `MaterialApp.router`를 설정한다.
   @override
   Widget build(BuildContext context) {
     return MultiProvider(

--- a/lib/app/navigation/adaptive_navigation_shell.dart
+++ b/lib/app/navigation/adaptive_navigation_shell.dart
@@ -8,6 +8,7 @@ import 'package:untitled3/features/auth/controllers/auth_controller.dart';
 import 'app_destinations.dart';
 import 'navigation_controller.dart';
 
+/// 화면 크기에 따라 내비게이션 패턴을 전환하는 껍데기 위젯입니다.
 class AdaptiveNavigationShell extends StatelessWidget {
   const AdaptiveNavigationShell({
     required this.state,
@@ -20,6 +21,7 @@ class AdaptiveNavigationShell extends StatelessWidget {
 
   static const double _navigationBreakpoint = 650;
 
+  /// 현재 라우트와 화면 폭을 고려해 적절한 내비게이션 UI를 결정합니다.
   @override
   Widget build(BuildContext context) {
     final navigation = context.watch<NavigationController>();
@@ -82,6 +84,7 @@ class AdaptiveNavigationShell extends StatelessWidget {
     );
   }
 
+  /// 현재 라우트에 해당하는 목적지 레이블을 반환합니다.
   String _titleForRoute(String location) {
     final match = appDestinations.firstWhere(
       (destination) => destination.location == location,
@@ -91,6 +94,7 @@ class AdaptiveNavigationShell extends StatelessWidget {
   }
 }
 
+/// 데스크톱·태블릿에서 사용할 사이드 드로어입니다.
 class AppDrawer extends StatelessWidget {
   const AppDrawer({
     required this.currentIndex,
@@ -103,6 +107,7 @@ class AppDrawer extends StatelessWidget {
   final AuthController authController;
   final ValueChanged<int> onDestinationSelected;
 
+  /// 목적지 목록을 드로어 항목으로 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     return Drawer(
@@ -150,6 +155,7 @@ class AppDrawer extends StatelessWidget {
   }
 }
 
+/// 목적지를 선택했을 때 라우터와 상태를 함께 갱신합니다.
 void _handleDestinationSelection(
   BuildContext context,
   NavigationController controller,
@@ -167,6 +173,7 @@ void _handleDestinationSelection(
   context.go(destination.location);
 }
 
+/// 로그인 상태에 따라 아이콘을 동적으로 변경합니다.
 IconData _iconForDestination(AppDestination destination, AuthController authController) {
   if (destination.name == 'login' && authController.currentUser != null) {
     return Icons.logout;
@@ -174,6 +181,7 @@ IconData _iconForDestination(AppDestination destination, AuthController authCont
   return destination.icon;
 }
 
+/// 로그인 여부에 따라 메뉴 라벨을 조정합니다.
 String _labelForDestination(AppDestination destination, AuthController authController) {
   if (destination.name == 'login' && authController.currentUser != null) {
     return '로그아웃';

--- a/lib/app/navigation/app_destinations.dart
+++ b/lib/app/navigation/app_destinations.dart
@@ -5,6 +5,7 @@ import 'package:untitled3/features/auth/view/login_page.dart';
 import 'package:untitled3/features/board/view/board_page.dart';
 import 'package:untitled3/features/simple_page/simple_page.dart';
 
+/// 내비게이션 바에 노출되는 목적지 정보를 표현하는 데이터 클래스.
 class AppDestination {
   const AppDestination({
     required this.location,
@@ -21,6 +22,7 @@ class AppDestination {
   final WidgetBuilder builder;
 }
 
+/// 앱 전역에서 사용되는 목적지 목록이다.
 final List<AppDestination> appDestinations = [
   AppDestination(
     location: '/',

--- a/lib/app/navigation/navigation_controller.dart
+++ b/lib/app/navigation/navigation_controller.dart
@@ -4,12 +4,15 @@ import 'package:flutter/foundation.dart';
 
 import 'app_destinations.dart';
 
+/// 라우터와 하단 내비게이션 상태를 연결하는 컨트롤러.
 class NavigationController extends ChangeNotifier {
   int _selectedIndex = 0;
   String _location = appDestinations.first.location;
 
+  /// 현재 선택된 목적지 인덱스.
   int get selectedIndex => _selectedIndex;
 
+  /// 인덱스를 변경하고 리스너에게 알린다.
   void selectIndex(int index) {
     if (index == _selectedIndex) {
       return;
@@ -19,6 +22,7 @@ class NavigationController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 라우터 위치와 내부 상태를 동기화한다.
   void syncWithLocation(String location) {
     if (_location == location) {
       return;

--- a/lib/app/router/app_router.dart
+++ b/lib/app/router/app_router.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../navigation/adaptive_navigation_shell.dart';
 import '../navigation/app_destinations.dart';
 
+/// 전역 라우팅 규칙과 셸 구성을 캡슐화한 클래스.
 class AppRouter {
   AppRouter();
 

--- a/lib/features/auth/controllers/auth_controller.dart
+++ b/lib/features/auth/controllers/auth_controller.dart
@@ -109,6 +109,7 @@ class AuthController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 인증 절차 공통 영역에서 로딩/에러 상태를 관리합니다.
   Future<void> _guardedExecution(Future<void> Function() action) async {
     _isLoading = true;
     _errorMessage = null;
@@ -125,6 +126,7 @@ class AuthController extends ChangeNotifier {
     }
   }
 
+  /// 사용자 정보, 지갑, 내가 쓴 글 캐시를 한 번에 로드합니다.
   Future<void> _hydrateSession(User user, {String? walletAddress}) async {
     _currentUser = user;
     _currentWallet = await _userRepository.fetchWallet(user.id);

--- a/lib/features/auth/models/user_grade.dart
+++ b/lib/features/auth/models/user_grade.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/auth/models/user_grade.dart
+// 파일 설명: 회원 권한 및 라벨 정보를 담은 열거형.
+
 /// 회원 등급을 정의한 열거형.
 enum UserGrade {
   all('모두', 0),

--- a/lib/features/auth/view/login_page.dart
+++ b/lib/features/auth/view/login_page.dart
@@ -23,6 +23,7 @@ class _LoginPageState extends State<LoginPage> {
   final GlobalKey<FormState> _socialFormKey = GlobalKey<FormState>();
   final TextEditingController _socialEmailController = TextEditingController();
 
+  /// 화면 종료 시 모든 입력 컨트롤러를 정리한다.
   @override
   void dispose() {
     _localEmailController.dispose();
@@ -31,6 +32,7 @@ class _LoginPageState extends State<LoginPage> {
     super.dispose();
   }
 
+  /// 인증 컨트롤러 상태를 구독해 로그인 UI를 구성한다.
   @override
   Widget build(BuildContext context) {
     return Consumer<AuthController>(
@@ -92,6 +94,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  /// 로컬 계정 로그인 폼을 렌더링하고 제출 이벤트를 처리한다.
   Widget _buildLocalLoginSection(
     BuildContext context,
     AuthController controller,
@@ -175,6 +178,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  /// 카카오·네이버 소셜 로그인을 위한 입력과 버튼을 제공한다.
   Widget _buildSocialLoginSection(
     BuildContext context,
     AuthController controller,
@@ -265,6 +269,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  /// 메타마스크 연결 안내와 서명 요청 버튼을 렌더링한다.
   Widget _buildMetamaskSection(
     BuildContext context,
     AuthController controller,
@@ -306,6 +311,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  /// 로그인 성공 후 회원·지갑 요약 정보를 보여준다.
   Widget _buildProfileOverview(
     BuildContext context,
     AuthController controller,
@@ -461,6 +467,7 @@ class _LoginPageState extends State<LoginPage> {
     );
   }
 
+  /// 열거형을 한글 라벨로 변환해 보여준다.
   String _loginTypeLabel(LoginType type) {
     switch (type) {
       case LoginType.local:
@@ -472,6 +479,7 @@ class _LoginPageState extends State<LoginPage> {
     }
   }
 
+  /// UTC/로컬 차이를 보정한 뒤 사용자 친화적인 문자열로 포맷한다.
   String _formatDate(DateTime dateTime) {
     final local = dateTime.toLocal();
     final year = local.year.toString().padLeft(4, '0');
@@ -483,6 +491,7 @@ class _LoginPageState extends State<LoginPage> {
   }
 }
 
+/// 회원 프로필 정보를 행 형태로 표시하는 보조 위젯.
 class _ProfileTile extends StatelessWidget {
   const _ProfileTile({
     required this.icon,
@@ -494,6 +503,7 @@ class _ProfileTile extends StatelessWidget {
   final String title;
   final String value;
 
+  /// 아이콘과 텍스트로 항목을 구성한다.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -526,6 +536,7 @@ class _ProfileTile extends StatelessWidget {
   }
 }
 
+/// 소셜 로그인 버튼을 테마에 맞춰 렌더링하는 위젯.
 class _SocialLoginButton extends StatelessWidget {
   const _SocialLoginButton({
     required this.label,
@@ -541,6 +552,7 @@ class _SocialLoginButton extends StatelessWidget {
   final Color foregroundColor;
   final VoidCallback? onPressed;
 
+  /// 카카오·네이버 스타일에 맞춘 버튼 모양을 구성한다.
   @override
   Widget build(BuildContext context) {
     return SizedBox(

--- a/lib/features/board/controllers/board_controller.dart
+++ b/lib/features/board/controllers/board_controller.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/controllers/board_controller.dart
+// 파일 설명: 게시글과 댓글을 관리하고 보기 모드를 전환하는 게시판 상태 컨트롤러.
+
 import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 
@@ -5,7 +8,9 @@ import '../data/board_repository.dart';
 import '../models/board_comment.dart';
 import '../models/board_post.dart';
 
+/// 자유 게시판 데이터를 전역에서 공유할 수 있도록 관리하는 ChangeNotifier입니다.
 class BoardController extends ChangeNotifier {
+  /// 게시글 저장소 의존성을 주입해 초기 데이터를 로드할 수 있게 합니다.
   BoardController({
     required BoardRepository repository,
   }) : _repository = repository;
@@ -15,10 +20,16 @@ class BoardController extends ChangeNotifier {
   bool _isLoading = false;
   BoardViewMode _viewMode = BoardViewMode.list;
 
+  /// 로딩 스피너 표시를 위한 상태 값입니다.
   bool get isLoading => _isLoading;
+
+  /// 리스트/갤러리 보기 중 현재 활성화된 모드입니다.
   BoardViewMode get viewMode => _viewMode;
+
+  /// 외부에서 수정하지 못하도록 방어 복사를 적용한 게시글 목록입니다.
   List<BoardPost> get posts => List<BoardPost>.unmodifiable(_posts);
 
+  /// 저장소에서 초기 게시글 목록을 불러와 상태를 초기화합니다.
   Future<void> loadInitialPosts() async {
     if (_isLoading) {
       return;
@@ -36,6 +47,7 @@ class BoardController extends ChangeNotifier {
     }
   }
 
+  /// 게시글 ID를 기준으로 게시글을 찾고, 없으면 null을 반환합니다.
   BoardPost? findById(String id) {
     try {
       return _posts.firstWhere((post) => post.id == id);
@@ -44,6 +56,7 @@ class BoardController extends ChangeNotifier {
     }
   }
 
+  /// 지정된 보기 모드로 전환하며 값이 달라질 때만 알림을 보냅니다.
   void setViewMode(BoardViewMode mode) {
     if (_viewMode == mode) {
       return;
@@ -52,11 +65,13 @@ class BoardController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 신규 게시글을 목록 맨 앞에 추가합니다.
   void addPost(BoardPost post) {
     _posts.insert(0, post);
     notifyListeners();
   }
 
+  /// 기존 게시글을 수정하고 즉시 UI에 반영합니다.
   void updatePost(BoardPost updated) {
     final index = _posts.indexWhere((post) => post.id == updated.id);
     if (index == -1) {
@@ -66,17 +81,20 @@ class BoardController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 게시글을 삭제하고 변경 사항을 구독자에게 전달합니다.
   void deletePost(String id) {
     _posts.removeWhere((post) => post.id == id);
     notifyListeners();
   }
 
+  /// 게시글의 조회수를 1 증가시킵니다.
   void registerView(String id) {
     _updatePost(id, (post) {
       return post.copyWith(views: post.views + 1);
     });
   }
 
+  /// 좋아요 또는 싫어요 반응을 적용합니다.
   void reactToPost(String id, {required bool like}) {
     _updatePost(id, (post) {
       if (like) {
@@ -86,6 +104,7 @@ class BoardController extends ChangeNotifier {
     });
   }
 
+  /// 댓글 혹은 대댓글을 추가해 댓글 트리를 갱신합니다.
   void addComment(
     String postId,
     BoardComment comment, {
@@ -111,6 +130,7 @@ class BoardController extends ChangeNotifier {
     });
   }
 
+  /// 댓글을 삭제하고 성공 여부에 따라 상태를 업데이트합니다.
   void deleteComment(String postId, String commentId) {
     _updatePost(postId, (post) {
       final (comments, removed) = _removeComment(post.comments, commentId);
@@ -121,8 +141,10 @@ class BoardController extends ChangeNotifier {
     });
   }
 
+  /// UUID 기반 댓글 식별자를 생성합니다.
   String generateCommentId() => const Uuid().v4();
 
+  /// 지정된 게시글에 변환 함수를 적용한 뒤 알림을 전파합니다.
   void _updatePost(String id, BoardPost Function(BoardPost post) transform) {
     final index = _posts.indexWhere((post) => post.id == id);
     if (index == -1) {
@@ -133,6 +155,7 @@ class BoardController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// 부모 댓글을 찾아 대댓글을 삽입하는 재귀 유틸리티입니다.
   (List<BoardComment>, bool) _insertReply(
     List<BoardComment> comments,
     String parentId,
@@ -162,6 +185,7 @@ class BoardController extends ChangeNotifier {
     return (updated, inserted);
   }
 
+  /// 댓글 ID를 찾아 삭제하는 재귀 유틸리티입니다.
   (List<BoardComment>, bool) _removeComment(
     List<BoardComment> comments,
     String commentId,

--- a/lib/features/board/data/board_repository.dart
+++ b/lib/features/board/data/board_repository.dart
@@ -1,10 +1,15 @@
+// 파일 경로: lib/features/board/data/board_repository.dart
+// 파일 설명: 로컬 JSON 자산에서 게시글 데이터를 불러오는 저장소 구현.
+
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
 import '../models/board_post.dart';
 
+/// 자유 게시판 게시글을 로컬 자산에서 읽어오는 리포지토리입니다.
 class BoardRepository {
+  /// 자산 경로와 번들을 주입해 테스트하기 쉽게 구성합니다.
   BoardRepository({
     this.assetPath = 'assets/data/free_board.json',
     AssetBundle? bundle,
@@ -13,6 +18,7 @@ class BoardRepository {
   final String assetPath;
   final AssetBundle bundle;
 
+  /// JSON 파일을 읽고 `BoardPost` 모델 리스트로 변환합니다.
   Future<List<BoardPost>> loadPosts() async {
     final raw = await bundle.loadString(assetPath);
     final Map<String, dynamic> jsonMap = json.decode(raw) as Map<String, dynamic>;
@@ -23,6 +29,7 @@ class BoardRepository {
     ];
   }
 
+  /// 본문에 누락된 이미지를 `<figure>` 태그로 삽입해 일관성을 유지합니다.
   BoardPost _embedImages(BoardPost post) {
     if (post.images.isEmpty) {
       return post;

--- a/lib/features/board/models/board_comment.dart
+++ b/lib/features/board/models/board_comment.dart
@@ -1,6 +1,11 @@
+// 파일 경로: lib/features/board/models/board_comment.dart
+// 파일 설명: 게시판 댓글과 대댓글 정보를 표현하는 데이터 모델.
+
 import 'package:equatable/equatable.dart';
 
+/// 댓글 본문과 작성 정보를 캡슐화한 모델입니다.
 class BoardComment extends Equatable {
+  /// 댓글 및 대댓글 생성 시 모든 필수 필드를 설정합니다.
   const BoardComment({
     required this.id,
     required this.nickname,
@@ -15,6 +20,7 @@ class BoardComment extends Equatable {
   final DateTime createdAt;
   final List<BoardComment> replies;
 
+  /// 불변 객체 특성을 유지하면서 일부 필드만 변경합니다.
   BoardComment copyWith({
     String? id,
     String? nickname,
@@ -31,6 +37,7 @@ class BoardComment extends Equatable {
     );
   }
 
+  /// JSON 맵으로부터 댓글 인스턴스를 생성합니다.
   factory BoardComment.fromJson(Map<String, dynamic> json) {
     return BoardComment(
       id: json['id'] as String,
@@ -44,6 +51,7 @@ class BoardComment extends Equatable {
     );
   }
 
+  /// API 연동을 위해 현재 상태를 JSON으로 직렬화합니다.
   Map<String, dynamic> toJson() {
     return {
       'id': id,

--- a/lib/features/board/models/board_post.dart
+++ b/lib/features/board/models/board_post.dart
@@ -1,13 +1,19 @@
+// 파일 경로: lib/features/board/models/board_post.dart
+// 파일 설명: 게시판 게시글과 보기 모드 열거형을 정의한 데이터 모델.
+
 import 'package:equatable/equatable.dart';
 
 import 'board_comment.dart';
 
+/// 게시판이 제공하는 화면 모드를 정의합니다.
 enum BoardViewMode {
   list,
   gallery,
 }
 
+/// 게시글 본문, 통계, 댓글 목록을 보유한 도메인 모델입니다.
 class BoardPost extends Equatable {
+  /// 게시글 생성자. 모든 필수 필드를 받아 불변 객체를 구성합니다.
   const BoardPost({
     required this.id,
     required this.title,
@@ -38,6 +44,7 @@ class BoardPost extends Equatable {
   final List<String> images;
   final List<BoardComment> comments;
 
+  /// 특정 필드만 수정한 새 게시글 인스턴스를 반환합니다.
   BoardPost copyWith({
     String? id,
     String? title,
@@ -70,6 +77,7 @@ class BoardPost extends Equatable {
     );
   }
 
+  /// JSON 데이터를 도메인 모델로 변환합니다.
   factory BoardPost.fromJson(Map<String, dynamic> json) {
     return BoardPost(
       id: json['id'] as String,
@@ -94,6 +102,7 @@ class BoardPost extends Equatable {
     );
   }
 
+  /// API 응답 등을 위해 현재 상태를 JSON으로 직렬화합니다.
   Map<String, dynamic> toJson() {
     return {
       'id': id,
@@ -114,6 +123,7 @@ class BoardPost extends Equatable {
     };
   }
 
+  /// 공유하기 기능에서 사용할 기본 메시지입니다.
   String get shareMessage => '[청록 네트워크] $title';
 
   @override

--- a/lib/features/board/view/board_page.dart
+++ b/lib/features/board/view/board_page.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/view/board_page.dart
+// 파일 설명: 자유 게시판 메인 화면과 리스트/갤러리 UI를 구성하는 위젯 모음.
+
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -13,9 +16,11 @@ import 'post_editor_page.dart';
 import 'widgets/post_gallery_tile.dart';
 import 'widgets/post_list_tile.dart';
 
+/// 자유 게시판 루트 화면을 정의하는 위젯입니다.
 class BoardPage extends StatelessWidget {
   const BoardPage({super.key});
 
+  /// 게시판 상태를 제공하고 최초 데이터를 로드합니다.
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<BoardController>(
@@ -26,9 +31,11 @@ class BoardPage extends StatelessWidget {
   }
 }
 
+/// 게시판 콘텐츠와 툴바, 작성 버튼을 그리는 내부 위젯입니다.
 class _BoardView extends StatelessWidget {
   const _BoardView();
 
+  /// 로그인 등급에 따라 보기 모드를 제어하고 화면을 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -78,6 +85,7 @@ class _BoardView extends StatelessWidget {
     );
   }
 
+  /// 새 글 작성 화면으로 이동합니다.
   void _openEditor(BuildContext context) {
     final controller = context.read<BoardController>();
     Navigator.of(context).push(
@@ -91,6 +99,7 @@ class _BoardView extends StatelessWidget {
   }
 }
 
+/// 게시판 상단 툴바(보기 모드, 통계)를 렌더링합니다.
 class _BoardToolbar extends StatelessWidget {
   const _BoardToolbar({
     required this.controller,
@@ -102,6 +111,7 @@ class _BoardToolbar extends StatelessWidget {
   final bool canChangeViewMode;
   final UserGrade? userGrade;
 
+  /// 사용자 등급과 게시글 수 정보를 보여줍니다.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -164,11 +174,13 @@ class _BoardToolbar extends StatelessWidget {
   }
 }
 
+/// 게시글 데이터를 기반으로 리스트 또는 갤러리 UI를 선택합니다.
 class _BoardContent extends StatelessWidget {
   const _BoardContent({required this.controller});
 
   final BoardController controller;
 
+  /// 게시글이 없으면 안내 문구, 있으면 애니메이션 전환을 제공합니다.
   @override
   Widget build(BuildContext context) {
     final posts = controller.posts;
@@ -190,11 +202,13 @@ class _BoardContent extends StatelessWidget {
   }
 }
 
+/// 게시글을 리스트 형태로 보여주는 위젯입니다.
 class _PostListView extends StatelessWidget {
   const _PostListView({required this.posts, super.key});
 
   final List<BoardPost> posts;
 
+  /// 게시글 목록을 `ListView`로 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     final controller = context.read<BoardController>();
@@ -214,11 +228,13 @@ class _PostListView extends StatelessWidget {
   }
 }
 
+/// 게시글을 갤러리 카드 형태로 보여주는 위젯입니다.
 class _PostGalleryView extends StatelessWidget {
   const _PostGalleryView({required this.posts, super.key});
 
   final List<BoardPost> posts;
 
+  /// 화면 크기에 따라 열 수를 조정하며 `GridView`를 구성합니다.
   @override
   Widget build(BuildContext context) {
     final controller = context.read<BoardController>();
@@ -248,6 +264,7 @@ class _PostGalleryView extends StatelessWidget {
   }
 }
 
+/// 게시글 상세 화면으로 이동하며 조회 수를 증가시킵니다.
 void _openDetail(BuildContext context, BoardController controller, BoardPost post) {
   controller.registerView(post.id);
   Navigator.of(context).push(

--- a/lib/features/board/view/post_detail_page.dart
+++ b/lib/features/board/view/post_detail_page.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/view/post_detail_page.dart
+// 파일 설명: 게시글 상세 화면과 댓글 쓰레드를 렌더링하는 위젯을 정의.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:intl/intl.dart';
@@ -10,6 +13,7 @@ import '../models/board_post.dart';
 import '../widgets/comment_utils.dart';
 import 'post_editor_page.dart';
 
+/// 게시글 본문과 통계, 댓글을 보여주는 상세 화면입니다.
 class PostDetailPage extends StatelessWidget {
   const PostDetailPage({
     required this.postId,
@@ -18,6 +22,7 @@ class PostDetailPage extends StatelessWidget {
 
   final String postId;
 
+  /// 게시글 정보를 찾아 화면을 구성합니다.
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<BoardController>();
@@ -145,11 +150,13 @@ class PostDetailPage extends StatelessWidget {
     );
   }
 
+  /// 공유하기 버튼 눌렀을 때 SNS로 텍스트를 전송합니다.
   void _sharePost(BoardPost post) {
     final url = 'https://cheongrok.community/posts/${post.id}';
     Share.share('${post.shareMessage}\n$url');
   }
 
+  /// 게시글 수정 화면으로 이동합니다.
   Future<void> _editPost(
     BuildContext context,
     BoardController controller,
@@ -165,6 +172,7 @@ class PostDetailPage extends StatelessWidget {
     );
   }
 
+  /// 삭제 확인 모달을 띄우고 승인 시 게시글을 제거합니다.
   Future<void> _deletePost(
     BuildContext context,
     BoardController controller,
@@ -191,6 +199,7 @@ class PostDetailPage extends StatelessWidget {
   }
 }
 
+/// 게시글 메타데이터를 아이콘과 함께 보여주는 작은 배지입니다.
 class _MetaChip extends StatelessWidget {
   const _MetaChip({
     required this.icon,
@@ -200,6 +209,7 @@ class _MetaChip extends StatelessWidget {
   final IconData icon;
   final String label;
 
+  /// 간결한 아이콘+텍스트 조합을 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     return Row(
@@ -213,6 +223,7 @@ class _MetaChip extends StatelessWidget {
   }
 }
 
+/// 댓글 입력, 목록, 답글 기능을 포함한 섹션입니다.
 class CommentSection extends StatefulWidget {
   const CommentSection({
     required this.postId,
@@ -227,6 +238,7 @@ class CommentSection extends StatefulWidget {
   State<CommentSection> createState() => _CommentSectionState();
 }
 
+/// 댓글 입력 폼과 쓰레드 리스트를 관리하는 상태 클래스입니다.
 class _CommentSectionState extends State<CommentSection> {
   final TextEditingController _nicknameController = TextEditingController();
   final TextEditingController _contentController = TextEditingController();
@@ -239,6 +251,7 @@ class _CommentSectionState extends State<CommentSection> {
     super.dispose();
   }
 
+  /// 댓글 수, 입력 폼, 쓰레드를 순서대로 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     final controller = context.watch<BoardController>();
@@ -311,6 +324,7 @@ class _CommentSectionState extends State<CommentSection> {
     );
   }
 
+  /// 폼 검증 후 댓글 또는 답글을 저장소에 추가합니다.
   Future<void> _submitComment(BoardController controller) async {
     final nickname = _nicknameController.text.trim();
     final content = _contentController.text.trim();
@@ -337,6 +351,7 @@ class _CommentSectionState extends State<CommentSection> {
     });
   }
 
+  /// 삭제 확인 후 지정된 댓글을 제거합니다.
   Future<void> _deleteComment(
     BuildContext context,
     BoardController controller,
@@ -362,6 +377,7 @@ class _CommentSectionState extends State<CommentSection> {
   }
 }
 
+/// 댓글 리스트를 재귀적으로 펼쳐서 보여주는 위젯입니다.
 class _CommentThread extends StatelessWidget {
   const _CommentThread({
     required this.comments,
@@ -375,6 +391,7 @@ class _CommentThread extends StatelessWidget {
   final ValueChanged<BoardComment> onDelete;
   final DateFormat dateFormat;
 
+  /// 댓글이 비어 있는 경우 안내 문구를, 아니면 댓글 타일 목록을 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     if (comments.isEmpty) {
@@ -395,6 +412,7 @@ class _CommentThread extends StatelessWidget {
   }
 }
 
+/// 단일 댓글과 하위 답글을 표현하는 위젯입니다.
 class _CommentTile extends StatelessWidget {
   const _CommentTile({
     required this.comment,
@@ -410,6 +428,7 @@ class _CommentTile extends StatelessWidget {
   final DateFormat dateFormat;
   final int depth;
 
+  /// 댓글 닉네임, 작성 시각, 본문, 동작 버튼을 차례로 보여줍니다.
   @override
   Widget build(BuildContext context) {
     final indent = depth * 16.0;

--- a/lib/features/board/view/post_editor_page.dart
+++ b/lib/features/board/view/post_editor_page.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/view/post_editor_page.dart
+// 파일 설명: 게시글 작성/수정 화면과 CKEditor 5 연동 로직을 포함한 위젯.
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -8,6 +11,7 @@ import '../controllers/board_controller.dart';
 import '../models/board_post.dart';
 import '../widgets/ckeditor5.dart';
 
+/// 게시글을 새로 작성하거나 기존 글을 수정하는 화면입니다.
 class PostEditorPage extends StatefulWidget {
   const PostEditorPage({
     this.initialPost,
@@ -16,12 +20,14 @@ class PostEditorPage extends StatefulWidget {
 
   final BoardPost? initialPost;
 
+  /// 초기 게시글 여부를 확인해 편집 모드인지 판별합니다.
   bool get isEditing => initialPost != null;
 
   @override
   State<PostEditorPage> createState() => _PostEditorPageState();
 }
 
+/// 게시글 작성 폼과 에디터 상태를 관리하는 State 클래스입니다.
 class _PostEditorPageState extends State<PostEditorPage> {
   final _formKey = GlobalKey<FormState>();
   late final TextEditingController _titleController;
@@ -45,6 +51,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
     'assets/pics/9.webp',
   ];
 
+  /// 초기 데이터나 로그인 정보를 읽어 폼 컨트롤러를 설정합니다.
   @override
   void initState() {
     super.initState();
@@ -66,6 +73,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
     }
   }
 
+  /// 화면 종료 시 컨트롤러 메모리를 해제합니다.
   @override
   void dispose() {
     _titleController.dispose();
@@ -74,6 +82,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
     super.dispose();
   }
 
+  /// 게시글 입력 폼과 CKEditor를 배치합니다.
   @override
   Widget build(BuildContext context) {
     final isEditing = widget.isEditing;
@@ -225,6 +234,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
     );
   }
 
+  /// 폼 검증 후 신규 게시글을 생성하거나 기존 글을 업데이트합니다.
   Future<void> _handleSubmit() async {
     if (!_formKey.currentState!.validate()) {
       return;
@@ -277,6 +287,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
     }
   }
 
+  /// 본문에 선택된 이미지가 누락돼 있으면 `<figure>` 태그를 추가합니다.
   String _mergeAttachedImages(String html, List<String> images) {
     if (images.isEmpty) {
       return html;
@@ -295,6 +306,7 @@ class _PostEditorPageState extends State<PostEditorPage> {
   }
 }
 
+/// 이미지 경로를 작은 썸네일로 보여주는 위젯입니다.
 class _ImagePreview extends StatelessWidget {
   const _ImagePreview({
     required this.path,
@@ -304,6 +316,7 @@ class _ImagePreview extends StatelessWidget {
   final String path;
   final double size;
 
+  /// 자산 이미지를 사각형으로 잘라 표시합니다.
   @override
   Widget build(BuildContext context) {
     return ClipRRect(

--- a/lib/features/board/view/widgets/post_gallery_tile.dart
+++ b/lib/features/board/view/widgets/post_gallery_tile.dart
@@ -1,8 +1,12 @@
+// 파일 경로: lib/features/board/view/widgets/post_gallery_tile.dart
+// 파일 설명: 게시글을 갤러리 카드 레이아웃으로 렌더링하는 위젯.
+
 import 'package:flutter/material.dart';
 
 import '../../models/board_post.dart';
 import '../../widgets/comment_utils.dart';
 
+/// 갤러리 모드에서 사용하는 게시글 카드 컴포넌트입니다.
 class PostGalleryTile extends StatelessWidget {
   const PostGalleryTile({
     required this.post,
@@ -15,6 +19,7 @@ class PostGalleryTile extends StatelessWidget {
   final String formattedDate;
   final VoidCallback onTap;
 
+  /// 커버 이미지와 통계를 포함한 카드 UI를 구성합니다.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -103,6 +108,7 @@ class PostGalleryTile extends StatelessWidget {
   }
 }
 
+/// 조회수, 좋아요 등을 숫자와 함께 출력하는 위젯입니다.
 class _IconStat extends StatelessWidget {
   const _IconStat({
     required this.icon,
@@ -112,6 +118,7 @@ class _IconStat extends StatelessWidget {
   final IconData icon;
   final int value;
 
+  /// 아이콘과 값을 한 줄로 보여줍니다.
   @override
   Widget build(BuildContext context) {
     return Row(

--- a/lib/features/board/view/widgets/post_list_tile.dart
+++ b/lib/features/board/view/widgets/post_list_tile.dart
@@ -1,8 +1,12 @@
+// 파일 경로: lib/features/board/view/widgets/post_list_tile.dart
+// 파일 설명: 게시글 리스트 카드 형태를 정의한 프레젠테이션 위젯.
+
 import 'package:flutter/material.dart';
 
 import '../../models/board_post.dart';
 import '../../widgets/comment_utils.dart';
 
+/// 자유 게시판 목록에서 단일 게시글을 카드로 보여주는 위젯입니다.
 class PostListTile extends StatelessWidget {
   const PostListTile({
     required this.post,
@@ -15,6 +19,7 @@ class PostListTile extends StatelessWidget {
   final String formattedDate;
   final VoidCallback onTap;
 
+  /// 게시글 요약 정보를 카드로 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -86,6 +91,7 @@ class PostListTile extends StatelessWidget {
   }
 }
 
+/// 게시글 부가 정보를 아이콘과 함께 보여주는 보조 위젯입니다.
 class _InfoChip extends StatelessWidget {
   const _InfoChip({
     required this.icon,
@@ -95,6 +101,7 @@ class _InfoChip extends StatelessWidget {
   final IconData icon;
   final String label;
 
+  /// 작은 아이콘과 텍스트 조합을 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     return Row(

--- a/lib/features/board/widgets/ckeditor5.dart
+++ b/lib/features/board/widgets/ckeditor5.dart
@@ -1,9 +1,12 @@
+// 파일 경로: lib/features/board/widgets/ckeditor5.dart
+// 파일 설명: CKEditor 5를 플랫폼별로 임베드하기 위한 컨트롤러와 위젯 정의.
+
 import 'package:flutter/material.dart';
 
 import 'ckeditor5_platform_interface.dart'
     if (dart.library.html) 'ckeditor5_platform_web.dart'
     if (dart.library.io) 'ckeditor5_platform_io.dart';
-
+/// 에디터와 상호 작용하기 위한 컨트롤러입니다.
 class Ckeditor5Controller {
   Ckeditor5Controller({String initialHtml = ''})
       : _html = initialHtml,
@@ -18,16 +21,19 @@ class Ckeditor5Controller {
 
   String get initialHtml => _html;
 
+  /// 에디터 State와 컨트롤러를 연결합니다.
   void _bind(_Ckeditor5State state) {
     _state = state;
   }
 
+  /// 현재 연결된 State가 동일할 때만 연결을 해제합니다.
   void _unbind(_Ckeditor5State state) {
     if (identical(_state, state)) {
       _state = null;
     }
   }
 
+  /// 컨트롤러에서 HTML을 설정하고 에디터에도 반영합니다.
   Future<void> setHtml(String html) async {
     _html = html;
     htmlListenable.value = html;
@@ -36,6 +42,7 @@ class Ckeditor5Controller {
     }
   }
 
+  /// 에디터에서 최신 HTML을 읽어옵니다.
   Future<String> getHtml() async {
     if (_state != null) {
       _html = await _state!.getHtmlFromEditor();
@@ -44,21 +51,25 @@ class Ckeditor5Controller {
     return _html;
   }
 
+  /// 에디터에서 전달된 HTML 변경을 반영합니다.
   void _handleHtmlChanged(String html) {
     _html = html;
     htmlListenable.value = html;
   }
 
+  /// 에디터 준비 완료 상태를 알립니다.
   void _markReady() {
     readyListenable.value = true;
   }
 
+  /// 내부적으로 생성한 리스너들을 정리합니다.
   void dispose() {
     htmlListenable.dispose();
     readyListenable.dispose();
   }
 }
 
+/// CKEditor 5를 표시하고 컨트롤러와 동기화하는 위젯입니다.
 class Ckeditor5 extends StatefulWidget {
   const Ckeditor5({
     required this.controller,
@@ -73,16 +84,19 @@ class Ckeditor5 extends StatefulWidget {
   State<Ckeditor5> createState() => _Ckeditor5State();
 }
 
+/// 플랫폼별 구현과 통신하는 State 클래스입니다.
 class _Ckeditor5State extends State<Ckeditor5> {
   Future<void> Function(String html)? _setHtmlCallback;
   Future<String> Function()? _getHtmlCallback;
 
+  /// 위젯이 마운트되면 컨트롤러와 연결합니다.
   @override
   void initState() {
     super.initState();
     widget.controller._bind(this);
   }
 
+  /// 컨트롤러가 바뀌었을 때 기존 연결을 정리합니다.
   @override
   void didUpdateWidget(Ckeditor5 oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -92,12 +106,14 @@ class _Ckeditor5State extends State<Ckeditor5> {
     }
   }
 
+  /// 위젯이 사라질 때 컨트롤러와의 연결을 해제합니다.
   @override
   void dispose() {
     widget.controller._unbind(this);
     super.dispose();
   }
 
+  /// 플랫폼별 구현에서 호출할 콜백을 등록합니다.
   void registerCallbacks({
     required Future<void> Function(String html) setHtml,
     required Future<String> Function() getHtml,
@@ -106,12 +122,14 @@ class _Ckeditor5State extends State<Ckeditor5> {
     _getHtmlCallback = getHtml;
   }
 
+  /// 컨트롤러에서 전달된 HTML을 플랫폼 구현에 반영합니다.
   Future<void> setHtmlFromController(String html) async {
     if (_setHtmlCallback != null) {
       await _setHtmlCallback!(html);
     }
   }
 
+  /// 플랫폼 구현에서 HTML을 읽어옵니다.
   Future<String> getHtmlFromEditor() async {
     if (_getHtmlCallback != null) {
       return _getHtmlCallback!();
@@ -119,6 +137,7 @@ class _Ckeditor5State extends State<Ckeditor5> {
     return widget.controller.initialHtml;
   }
 
+  /// 에디터 로드 완료 시 초기 HTML을 세팅합니다.
   void handleEditorReady() {
     widget.controller._markReady();
     if (widget.controller.initialHtml.isNotEmpty) {
@@ -126,10 +145,12 @@ class _Ckeditor5State extends State<Ckeditor5> {
     }
   }
 
+  /// 플랫폼 구현으로부터 전달된 HTML 변화를 컨트롤러에 반영합니다.
   void handleHtmlChanged(String html) {
     widget.controller._handleHtmlChanged(html);
   }
 
+  /// 플랫폼별 위젯을 생성해 렌더링합니다.
   @override
   Widget build(BuildContext context) {
     return buildPlatformEditor(

--- a/lib/features/board/widgets/ckeditor5_platform_interface.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_interface.dart
@@ -1,13 +1,21 @@
+// 파일 경로: lib/features/board/widgets/ckeditor5_platform_interface.dart
+// 파일 설명: 플랫폼별 CKEditor 구현을 위한 추상 인터페이스와 기본 폴백 UI.
+
 import 'package:flutter/material.dart';
 
+/// 플랫폼 구현이 HTML 동기화 콜백을 등록할 때 사용하는 시그니처입니다.
 typedef CkeditorRegisterCallbacks = void Function({
   required Future<void> Function(String html) setHtml,
   required Future<String> Function() getHtml,
 });
 
+/// 에디터 로드 완료를 알리는 콜백입니다.
 typedef CkeditorReadyCallback = void Function();
+
+/// HTML 변경 시 호출되는 콜백입니다.
 typedef CkeditorChangedCallback = void Function(String html);
 
+/// 지원되지 않는 플랫폼에서 보여줄 폴백 에디터 위젯입니다.
 Widget buildPlatformEditor({
   required double minHeight,
   required String initialHtml,

--- a/lib/features/board/widgets/ckeditor5_platform_io.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_io.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/widgets/ckeditor5_platform_io.dart
+// 파일 설명: 모바일/데스크톱에서 WebView 기반 CKEditor 5를 제공하는 구현.
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -6,6 +9,7 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 import 'ckeditor5_platform_interface.dart' hide buildPlatformEditor;
 
+/// WebView를 생성해 CKEditor 5를 로드하고 콜백을 등록합니다.
 Widget buildPlatformEditor({
   required double minHeight,
   required String initialHtml,
@@ -67,6 +71,7 @@ Widget buildPlatformEditor({
   );
 }
 
+/// WebView에서 실행할 CKEditor 5 HTML 템플릿을 생성합니다.
 String _buildEditorHtml(String initialHtml) {
   final escapedInitial = jsonEncode(initialHtml);
   return '''

--- a/lib/features/board/widgets/ckeditor5_platform_web.dart
+++ b/lib/features/board/widgets/ckeditor5_platform_web.dart
@@ -1,3 +1,6 @@
+// 파일 경로: lib/features/board/widgets/ckeditor5_platform_web.dart
+// 파일 설명: 웹 환경에서 iframe 기반 CKEditor 5를 제공하는 구현.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:html' as html;
@@ -7,6 +10,7 @@ import 'package:flutter/material.dart';
 
 import 'ckeditor5_platform_interface.dart' hide buildPlatformEditor;
 
+/// IFrameElement를 생성해 웹 전용 CKEditor 5를 렌더링합니다.
 Widget buildPlatformEditor({
   required double minHeight,
   required String initialHtml,
@@ -91,6 +95,7 @@ Widget buildPlatformEditor({
   );
 }
 
+/// iframe에 주입할 CKEditor 5 HTML 문자열을 생성합니다.
 String _buildEditorHtml(String initialHtml, String editorId) {
   final escapedInitial = jsonEncode(initialHtml);
   final escapedId = jsonEncode(editorId);

--- a/lib/features/board/widgets/comment_utils.dart
+++ b/lib/features/board/widgets/comment_utils.dart
@@ -1,5 +1,9 @@
+// 파일 경로: lib/features/board/widgets/comment_utils.dart
+// 파일 설명: 댓글 관련 공통 유틸리티 함수 모음.
+
 import '../models/board_comment.dart';
 
+/// 댓글과 모든 대댓글 수를 재귀적으로 합산합니다.
 int countComments(List<BoardComment> comments) {
   var total = 0;
   for (final comment in comments) {

--- a/lib/features/simple_page/simple_page.dart
+++ b/lib/features/simple_page/simple_page.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/material.dart';
 
+/// 특정 기능이 준비되지 않았을 때 안내 메시지를 보여주는 단순 페이지.
 class SimplePage extends StatelessWidget {
   const SimplePage({
     required this.message,
@@ -11,6 +12,7 @@ class SimplePage extends StatelessWidget {
 
   final String message;
 
+  /// 전달받은 메시지를 중앙 정렬 텍스트로 출력한다.
   @override
   Widget build(BuildContext context) {
     return Center(


### PR DESCRIPTION
## Summary
- update the README project tree and feature descriptions to reflect the current layout
- add Korean path headers and detailed inline comments across board and auth modules, especially for authentication flows and CKEditor widgets
- document supporting widgets/controllers so each file exposes its responsibility in Korean at the top

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3fc4a3e148322b1df8d77b1e1c86b